### PR TITLE
Aug 31 patch

### DIFF
--- a/src/loaders/transactions/bgi.py
+++ b/src/loaders/transactions/bgi.py
@@ -69,7 +69,7 @@ class BGITransaction(Transaction):
 
             WITH row.crossReferences as events
             UNWIND events as event
-                MERGE (id:CrossReference:Entity {primaryKey:event.id})
+                MERGE (id:CrossReference {primaryKey:event.id})
                 ON CREATE SET id.name = event.id
                 ON CREATE SET id.globalCrosssrefId = event.crossRef
                 ON CREATE SET id.localId = event.localId

--- a/src/loaders/transactions/bgi.py
+++ b/src/loaders/transactions/bgi.py
@@ -16,7 +16,7 @@ class BGITransaction(Transaction):
         # quit()
 
         query = """
-            UNWIND $data as row
+            UNWIND $data AS row
 
             //Create the Gene node and set properties. primaryKey is required.
             CREATE (g:Gene {primaryKey:row.primaryId})
@@ -67,8 +67,8 @@ class BGITransaction(Transaction):
             //Create the entity relationship to the gene node.
             MERGE (g)-[c1:CREATED_BY]->(ent)
 
-            WITH row.crossReferences, g as events
-            UNWIND events as event
+            WITH g, row.crossReferences AS events
+            UNWIND events AS event
                 MERGE (id:CrossReference {primaryKey:event.id})
                 ON CREATE SET id.name = event.id
                 ON CREATE SET id.globalCrosssrefId = event.crossRef
@@ -78,9 +78,9 @@ class BGITransaction(Transaction):
         """
 
         locationQuery = """
-            UNWIND $data as row
-                WITH row.genomeLocations as locations
-                UNWIND locations as location
+            UNWIND $data AS row
+                WITH row.genomeLocations AS locations
+                UNWIND locations AS location
                     //TODO: this is super annoying -- without this second pass of merging gene, it creates new gene nodes!
                     MATCH (g:Gene {primaryKey:location.geneLocPrimaryId})
 

--- a/src/loaders/transactions/bgi.py
+++ b/src/loaders/transactions/bgi.py
@@ -67,7 +67,7 @@ class BGITransaction(Transaction):
             //Create the entity relationship to the gene node.
             MERGE (g)-[c1:CREATED_BY]->(ent)
 
-            WITH row.crossReferences as events
+            WITH row.crossReferences, g as events
             UNWIND events as event
                 MERGE (id:CrossReference {primaryKey:event.id})
                 ON CREATE SET id.name = event.id

--- a/src/loaders/transactions/indicies.py
+++ b/src/loaders/transactions/indicies.py
@@ -17,8 +17,6 @@ class Indicies(object):
         session.run("CREATE INDEX ON :Transgene(primaryKey)")
         session.run("CREATE INDEX ON :Fish(primaryKey)")
         session.run("CREATE INDEX ON :DiseaseObject(primaryKey)")
-        session.run("CREATE INDEX ON :LocationObject(primaryKey)")
-        session.run("CREATE INDEX ON :Location(primaryKey)")
         session.run("CREATE INDEX ON :EnvironmentCondition(primaryKey)")
         session.run("CREATE INDEX ON :Environment(primaryKey)")
         session.run("CREATE INDEX ON :Species(primaryKey)")

--- a/src/loaders/transactions/orthology.py
+++ b/src/loaders/transactions/orthology.py
@@ -27,6 +27,8 @@ class OrthoTransaction(Transaction):
 
             //Create the Association node to be used for the object/doTerm
             MERGE (oa:Association {primaryKey:row.uuid})
+                ON CREATE SET oa :OrthologyGeneJoin
+                ON CREATE SET oa.joinType = 'orthologous'
             MERGE (g1)-[a1:ASSOCIATION]->(oa)
             MERGE (oa)-[a2:ASSOCIATION]->(g2)
 


### PR DESCRIPTION
1. indexes on the UUID fields? - Already exist (as Association {primaryKey})
2. Why are all CrossRefences labeled as Entity’s? - Removed :Entity
3. Remove Indexes: Location(primaryKey), LocationObject - Done
4. CrossReferences -> Genes’s are Broke - Fixed
5. Can the Association nodes for Orthology be Labeled with something? - Following Sierra's naming convention and used `:OrthologyGeneJoin`.