### PR TITLE
AGR-1155 Interactor ID resolution fix

### DIFF
--- a/src/extractors/mol_int_ext.py
+++ b/src/extractors/mol_int_ext.py
@@ -321,10 +321,6 @@ class MolIntExt(object):
                 # Update the dictionary with every possible combination of interactor A x interactor B.
                 list_of_mol_int_dataset = [dict(mol_int_dataset, interactor_A=x, interactor_B=y, uuid=str(uuid.uuid4())) for x,y in int_combos]
 
-                # if len(interactor_A_resolved) > 1 or len(interactor_B_resolved) > 1:
-                #     pp.pprint(list_of_mol_int_dataset)
-                #     quit()
-
                 resolved_a_b_count += 1 # Tracking successfully resolved identifiers.
 
                 # Establishes the number of entries to yield (return) at a time.

--- a/src/extractors/mol_int_ext.py
+++ b/src/extractors/mol_int_ext.py
@@ -1,6 +1,6 @@
 from files import S3File, TARFile
 import uuid, csv, re, sys
-import urllib.request, json, pprint
+import urllib.request, json, pprint, itertools
 from services import ResourceDescriptor
 from types import ModuleType
 
@@ -60,7 +60,15 @@ class MolIntExt(object):
                     cross_ref_record = 'entrez gene/locuslink:' + cross_ref_record_split
                 else:
                     cross_ref_record = record['cr.globalCrossRefId']
-                master_crossreference_dictionary[key][cross_ref_record.lower()] = record['g.primaryKey'] 
+
+                # The crossreference dictionary is a list of genes linked to a single crossreference.
+                # Append the gene if the crossref dict entry exists. Otherwise, create a list and append the entry.
+                if cross_ref_record.lower() in master_crossreference_dictionary[key]:
+                    master_crossreference_dictionary[key][cross_ref_record.lower()].append(record['g.primaryKey'])
+                else:
+                    master_crossreference_dictionary[key][cross_ref_record.lower()] = []
+                    master_crossreference_dictionary[key][cross_ref_record.lower()].append(record['g.primaryKey'])
+
                 # The ids in PSI-MITAB files are lower case, hence the .lower() used above.
 
         return master_crossreference_dictionary
@@ -151,7 +159,6 @@ class MolIntExt(object):
         # All valid identifiers in the PSI-MI TAB file should be "splittable".
         try:
             entry_stripped = row_entry.split(':')[1]
-            # print('entry_stripped: %s' % (entry_stripped))
         except IndexError:
             return None
 
@@ -178,8 +185,7 @@ class MolIntExt(object):
                 for crossreference_type in master_crossreference_dictionary.keys():
                     # Using lowercase in the identifier to be consistent with Alliance lowercase identifiers.
                     if identifier.lower() in master_crossreference_dictionary[crossreference_type]:
-                        # print('Found crossref: %s for gene: %s' % (identifier.lower(), master_crossreference_dictionary[crossreference_type][identifier.lower()]))
-                        return master_crossreference_dictionary[crossreference_type][identifier.lower()] # Return the corresponding Alliance gene.
+                        return master_crossreference_dictionary[crossreference_type][identifier.lower()] # Return the corresponding Alliance gene(s).
 
         # If we can't resolve any of the crossReferences, return None
         return None            
@@ -203,14 +209,16 @@ class MolIntExt(object):
         # Populate our master gene set for filtering Alliance genes.
         master_gene_set = self.populate_genes(self.graph)
 
-        resolved_a_b_list = []
-        unresolved_a_b_list = []
+        resolved_a_b_count = 0
+        unresolved_a_b_count = 0
+        pp = pprint.PrettyPrinter(indent=4)
 
         with open(path + "/" + filename, 'r', encoding='utf-8') as tsvin:
             tsvin = csv.reader(tsvin, delimiter='\t')
             next(tsvin, None) # Skip the headers
 
             for row in tsvin:
+                
                 taxon_id_1 = row[9]
                 taxon_id_2 = row[10]
 
@@ -276,17 +284,21 @@ class MolIntExt(object):
                 interactor_A_type = re.findall(r'"([^"]*)"', row[20])[0]
                 interactor_B_type = re.findall(r'"([^"]*)"', row[21])[0]
 
+                interaction_type = None
+                interaction_type = re.findall(r'"([^"]*)"', row[11])[0]
+
                 interactor_A_resolved = None
                 interactor_B_resolved = None
 
                 interactor_A_resolved, interactor_B_resolved = self.resolve_identifiers_by_row(row, master_gene_set, master_crossreference_dictionary)
 
-                interaction_type = None
-                interaction_type = re.findall(r'"([^"]*)"', row[11])[0]
-
+                if interactor_A_resolved is None or interactor_B_resolved is None:
+                    unresolved_a_b_count += 1 # Tracking unresolved identifiers.
+                    continue # Skip this entry.
+            
                 mol_int_dataset = {
-                    'interactor_A' : interactor_A_resolved,
-                    'interactor_B' : interactor_B_resolved,
+                    'interactor_A' : None,
+                    'interactor_B' : None,
                     'interactor_A_type' : interactor_A_type,
                     'interactor_B_type' : interactor_B_type,
                     'interactor_A_role' : interactor_A_role,
@@ -297,35 +309,37 @@ class MolIntExt(object):
                     'detection_method' : detection_method,
                     'pub_med_id' : publication,
                     'pub_med_url' : publication_url,
-                    'uuid' : str(uuid.uuid4()),
+                    'uuid' : None,
                     'source_database' : source_database,
                     'aggregation_database' :  aggregation_database,
                     'interactor_id_and_linkout' : identifier_linkout_list # Crossreferences
                 }
 
-                if interactor_A_resolved is not None and interactor_B_resolved is not None:
-                    resolved_a_b_list.append(mol_int_dataset)
-                
-                if interactor_A_resolved is None or interactor_B_resolved is None:
-                    # print(row)
-                    unresolved_a_b_list.append(mol_int_dataset)
-                    continue # Skip this entry.
+                # Get every possible combination of interactor A x interactor B (if multiple ids resulted from resolving the identifier.)
+                int_combos = list(itertools.product(interactor_A_resolved, interactor_B_resolved))
+
+                # Update the dictionary with every possible combination of interactor A x interactor B.
+                list_of_mol_int_dataset = [dict(mol_int_dataset, interactor_A=x, interactor_B=y, uuid=str(uuid.uuid4())) for x,y in int_combos]
+
+                # if len(interactor_A_resolved) > 1 or len(interactor_B_resolved) > 1:
+                #     pp.pprint(list_of_mol_int_dataset)
+                #     quit()
+
+                resolved_a_b_count += 1 # Tracking successfully resolved identifiers.
 
                 # Establishes the number of entries to yield (return) at a time.
-                list_to_yield.append(mol_int_dataset)
-                if len(list_to_yield) == batch_size:
+                list_to_yield.extend(list_of_mol_int_dataset)
+                if len(list_to_yield) >= batch_size: # We're possibly extending by more than one at a time, need to add 'greater than'.
                     yield list_to_yield
                     list_to_yield[:] = []  # Empty the list.
 
             if len(list_to_yield) > 0:
                 yield list_to_yield
 
-        pp = pprint.PrettyPrinter(indent=4)
-
-        print('Resolved identifiers and loaded %s interactions' % len(resolved_a_b_list))
+        print('Resolved identifiers and loaded %s interactions' % resolved_a_b_count)
         print('Successfully created linkouts for the following identifier databases:')
         pp.pprint(self.successful_database_linkouts)
 
-        print('Could not resolve [and subsequently did not load] %s interactions' % len(unresolved_a_b_list))
+        print('Could not resolve [and subsequently did not load] %s interactions' % unresolved_a_b_count)
         print('Could not create linkouts for the following identifier databases:')
         pp.pprint(self.missed_database_linkouts)


### PR DESCRIPTION
Allows for single cross reference identifiers (_e.g._ one unitprot ID) to resolve to several gene identifiers for loading interaction data.