### PR TITLE
Genedescriptions reports and orthology

### DIFF
--- a/src/aggregate_loader.py
+++ b/src/aggregate_loader.py
@@ -1,6 +1,5 @@
 import os, csv, time
 import gc
-from genedescriptions.data_fetcher import DataFetcher
 from loaders import *
 from loaders.transactions import *
 from loaders.allele_loader import *
@@ -311,11 +310,7 @@ class AggregateLoader(object):
                                                                           self.graph, mod.species),
                     ortho_data=OrthoExt().get_data(self.testObject, mod.__class__.__name__, self.batch_size),
                     data_provider=mod.dataProvider, cached_data_fetcher=cached_data_fetcher,
-                    human=isinstance(mod, Human),
-                    go_ontology_url="https://download.alliancegenome.org/GO/go_1.7.obo",
-                    go_association_url="https://download.alliancegenome.org/GO/ANNOT/" + mod.geneAssociationFile,
-                    do_ontology_url="https://download.alliancegenome.org/DO/do_1.7.obo",
-                    do_association_url="")
+                    human=isinstance(mod, Human))
 
     def load_additional_datasets(self):
             logger.info("Extracting and Loading Molecular Interaction data.")

--- a/src/services/gene_descriptions/data_extraction_functions.py
+++ b/src/services/gene_descriptions/data_extraction_functions.py
@@ -147,7 +147,7 @@ def get_do_associations_from_loader_object(do_annotations, do_annotations_allele
     #                          "relation": {"id": None},
     #                          "negated": False,
     #                          "evidence": {
-    #                              "type": "IEA",
+    #                              "type": "DVO",
     #                              "has_supporting_reference": "",
     #                              "with_support_from": [],
     #                              "provided_by": data_provider,

--- a/src/services/gene_descriptions/descriptions_generator.py
+++ b/src/services/gene_descriptions/descriptions_generator.py
@@ -1,6 +1,5 @@
 import datetime
 import os
-from collections import defaultdict
 import boto3
 from genedescriptions.config_parser import GenedescConfigParser
 from genedescriptions.data_fetcher import DataFetcher, DataType
@@ -305,8 +304,8 @@ class GeneDescGenerator(object):
                 gene_desc.orthology_description = orth_sent
 
     def generate_descriptions(self, go_annotations, do_annotations, do_annotations_allele, ortho_data, data_provider,
-                              cached_data_fetcher, go_ontology_url, go_association_url,
-                              do_ontology_url, do_association_url, human=False) -> DataFetcher:
+                              cached_data_fetcher, go_ontology_url="", go_association_url="",
+                              do_ontology_url="", do_association_url="", human=False) -> DataFetcher:
         # Generate gene descriptions and save to db
         json_desc_writer = Neo4jGDWriter()
         if cached_data_fetcher:

--- a/src/services/gene_descriptions/descriptions_generator.py
+++ b/src/services/gene_descriptions/descriptions_generator.py
@@ -35,12 +35,14 @@ class GeneDescGenerator(object):
             "evidence_codes_groups_map": self.conf_parser.get_do_evidence_codes_groups_map()}
         self.do_sent_common_props = {
             "remove_parent_terms": False,
-            "merge_num_terms_threshold": 3,
+            "merge_num_terms_threshold": self.conf_parser.get_do_trim_min_num_terms(),
+            "merge_max_num_terms": self.conf_parser.get_do_max_num_terms(),
             "merge_min_distance_from_root": self.conf_parser.get_do_trim_min_distance_from_root(),
             "truncate_others_generic_word": self.conf_parser.get_do_truncate_others_aggregation_word(),
             "truncate_others_aspect_words": self.conf_parser.get_do_truncate_others_terms(),
             "add_multiple_if_covers_more_children": True,
-            "remove_successive_overlapped_terms": False}
+            "remove_successive_overlapped_terms": False,
+            "blacklisted_ancestors": self.conf_parser.get_do_terms_exclusion_list()}
         self.do_via_orth_sent_gen_common_prop = {
             "evidence_groups_priority_list": self.conf_parser.get_do_via_orth_evidence_groups_priority_list(),
             "prepostfix_sentences_map": self.conf_parser.get_do_via_orth_prepostfix_sentences_map(),
@@ -48,12 +50,14 @@ class GeneDescGenerator(object):
             "evidence_codes_groups_map": self.conf_parser.get_do_via_orth_evidence_codes_groups_map()}
         self.do_via_orth_sent_common_props = {
             "remove_parent_terms": False,
-            "merge_num_terms_threshold": 3,
+            "merge_num_terms_threshold": self.conf_parser.get_do_via_orth_trim_min_num_terms(),
+            "merge_max_num_terms": self.conf_parser.get_do_via_orth_max_num_terms(),
             "merge_min_distance_from_root": self.conf_parser.get_do_via_orth_trim_min_distance_from_root(),
             "truncate_others_generic_word": self.conf_parser.get_do_via_orth_truncate_others_aggregation_word(),
             "truncate_others_aspect_words": self.conf_parser.get_do_via_orth_truncate_others_terms(),
             "add_multiple_if_covers_more_children": True,
-            "remove_successive_overlapped_terms": False}
+            "remove_successive_overlapped_terms": False,
+            "blacklisted_ancestors": self.conf_parser.get_do_terms_exclusion_list()}
 
     def create_orthology_sentence(self):
         pass

--- a/src/services/gene_descriptions/genedesc_config.yml
+++ b/src/services/gene_descriptions/genedesc_config.yml
@@ -498,6 +498,7 @@ go_sentences_options:
     remove_parents_if_children_are_present: true
     trim_terms_by_common_ancestors: true
     trim_if_more_than_terms: 3
+    max_num_terms: 5
     trim_min_distance_from_root:
         F: 3
         P: 5
@@ -562,7 +563,7 @@ do_sentences_options:
 
     remove_parents_if_children_are_present: true
     trim_terms_by_common_ancestors: true
-    trim_if_more_than_terms: 3
+    trim_if_more_than_terms: 5
     trim_min_distance_from_root:
         D: 4
     do_truncate_others_aggregation_word: several
@@ -582,12 +583,9 @@ do_via_orth_sentences_options:
         - "DOID:0050117"
         - "DOID:0080014"
     evidence_codes:
-        ISS:
+        DVO:
             group: ORTHOLOGY_BASED
             priority: 1
-        IEA:
-            group: ORTHOLOGY_BASED
-            priority: 2
     group_priority:
         ORTHOLOGY_BASED: 1
     do_prepostfix_sentences_map:

--- a/src/services/gene_descriptions/genedesc_config.yml
+++ b/src/services/gene_descriptions/genedesc_config.yml
@@ -498,7 +498,7 @@ go_sentences_options:
     remove_parents_if_children_are_present: true
     trim_terms_by_common_ancestors: true
     trim_if_more_than_terms: 3
-    max_num_terms: 5
+    max_num_terms: 3
     trim_min_distance_from_root:
         F: 3
         P: 5
@@ -564,6 +564,7 @@ do_sentences_options:
     remove_parents_if_children_are_present: true
     trim_terms_by_common_ancestors: true
     trim_if_more_than_terms: 5
+    max_num_terms: 5
     trim_min_distance_from_root:
         D: 4
     do_truncate_others_aggregation_word: several
@@ -603,7 +604,8 @@ do_via_orth_sentences_options:
 
     remove_parents_if_children_are_present: true
     trim_terms_by_common_ancestors: true
-    trim_if_more_than_terms: 3
+    trim_if_more_than_terms: 5
+    max_num_terms: 5
     trim_min_distance_from_root:
         D: 4
     do_truncate_others_aggregation_word: several


### PR DESCRIPTION
hotfix to include key diseases in the descriptions by increasing the number of displayed terms from 3 to 5 and other small changes