### PR TITLE
AGR-1246

### DIFF
--- a/src/aggregate_loader.py
+++ b/src/aggregate_loader.py
@@ -76,7 +76,9 @@ class AggregateLoader(object):
         # Does not get cleared because its used later self.go_dataset.clear()
 
         logger.info("Extracting DO data.")
-        self.do_dataset = OExt().get_data("http://purl.obolibrary.org/obo/doid.obo", "doid.obo")
+
+        #TODO: Oct 24 version of DO is broken, go back a release for 2.0
+        self.do_dataset = OExt().get_data("https://raw.githubusercontent.com/DiseaseOntology/HumanDiseaseOntology/834f2cacd7876b74915928cafdcaf663ac5f089f/src/ontology/doid.obo", "doid.obo")
         logger.info("Loading DO data into Neo4j.")
         DOLoader(self.graph).load_do(self.do_dataset)
         # Does not get cleared because its used later self.do_dataset.clear()

--- a/src/extractors/wt_expression_ext.py
+++ b/src/extractors/wt_expression_ext.py
@@ -61,11 +61,23 @@ class WTExpressionExt(object):
 
                 if 'modPublicationId' in evidence:
                     publicationModId = evidence.get('modPublicationId')
-                    pubModLocalId = publicationModId.split(":")[1]
-                    pubModPrefix = publicationModId.split(":")[0]
-                    pubModUrl = UrlService.get_page_complete_url(pubModLocalId, xrefUrlMap, pubModPrefix, "gene/references")
+                    if publicationModId is not None:
+                        pubModLocalId = publicationModId.split(":")[1]
+                        if "MGI:" in publicationModId:
+                            pubModUrl = "http://www.informatics.jax.org/reference/" + publicationModId
+                        if "ZFIN:" in publicationModId:
+                            pubModUrl = "http://zfin.org/" + publicationModId
+                        if "SGD:" in publicationModId:
+                            pubModUrl = "https://www.yeastgenome.org/reference/" + pubModLocalId
+                        if "WB:" in publicationModId:
+                            pubModUrl = "https://www.wormbase.org/db/get?name=" + pubModLocalId + ";class=Paper"
+                        if "RGD:" in publicationModId:
+                            pubModUrl = "https://rgd.mcw.edu/rgdweb/report/reference/main.html?id=" + pubModLocalId
+                        if "FB:" in publicationModId:
+                            pubModUrl = "http://flybase.org/reports/" + pubModLocalId
+
                     if publicationModId is None:
-                        publicationModId =""
+                        publicationModId = ""
 
                 if 'pubMedId' in evidence:
                     pubMedId = evidence.get('pubMedId')


### PR DESCRIPTION
publication mod id should be a cross reference in the expression schema instead of a global id (perhaps throughout the schemas repo).  for ~2.1 we can extract the pub specific url from the submission file like the others.  for 2.0, include the corrected urls in the loader.

also used the Oct. 11 version of the DO as the version out today fails on cross references and synonyms.    