### PR TITLE
I was using neo4j version 2 Cypher query syntax - looks clean now

### DIFF
--- a/src/aggregate_loader.py
+++ b/src/aggregate_loader.py
@@ -352,7 +352,7 @@ class AggregateLoader(object):
             logger.info("loading gocc self ribbon terms for all MODs")
             gocc_self_ribbon_terms = tx.retrieve_gocc_self_ribbon_terms()
 
-            logger.info("insrting gocc self ribbon terms for all MODs")
+            logger.info("inserting gocc self ribbon terms for all MODs")
             tx.insert_gocc_self_ribbon_terms(gocc_self_ribbon_terms)
 
             logger.info("retrieving gocc ribbonless ebes for all MODs")

--- a/src/loaders/transactions/gene_disease_ortho.py
+++ b/src/loaders/transactions/gene_disease_ortho.py
@@ -29,8 +29,6 @@ class GeneDiseaseOrthoTransaction(Transaction):
                  AND NOT ec.primaryKey IN ["IEA", "ISS", "ISO"]
                  AND NOT (disease:DOTerm)<-[:IS_IMPLICATED_IN|IS_MARKER_FOR]-(gene2:Gene)
                  AND NOT (gene2:Gene)-[:IS_ALLELE_OF]->(:Feature)-[:IS_IMPLICATED_IN|IS_MARKER_FOR]-(disease:DOTerm)
-                 AND gene2.primaryKey = "RGD:620474"
-                 AND gene1.primaryKey = "HGNC:11204"
         RETURN DISTINCT gene2.primaryKey AS geneID,
                gene1.primaryKey AS fromGeneID,
                type(da) AS relationType,


### PR DESCRIPTION
I have tested this by fully building the database from scratch and then testing different orthologous genes. Mainly focusing on gene MGI:98371 and HGNC:11204

I don't think this change fixes anything but it makes the query a lot more readable. 

@sierra-moxon if you could look at the results and see if you can confirm the data in the database seams correct. By confirm I mean look at the edges associated with the two genes above and see if you think they look right

@cmpich Do you think you could look into the query from the API / indexer. The curators are saying that nothing is showing up for MGI with regards to gene-disease associations. I will forward you the email with more information. 

* Staring at these nodes and edges for these associations gets to be quite complicated. I did the best I can to reason through the nodes and edges. From what I saw they looked right with this pull request. I am not sure about before the pull request... running out of time today. 