### PR TITLE
Update interactions file link for 2.1

### DIFF
--- a/src/config/local_submission.json
+++ b/src/config/local_submission.json
@@ -219,7 +219,7 @@
                 "schemaVersion": "1.0.0.7",
                 "dataType": "Interactions",
                 "taxonIDPart": "MolecularInteraction",
-                "s3path": "INT/Alliance_molecular_interactions_2.1.tar.gz",
+                "s3path": "INT/Alliance_molecular_interactions.tar.gz",
                 "tempExtractedFile": "Alliance_molecular_interactions_2.1.txt",
                 "uploadDate": 1522181475376
             }


### PR DESCRIPTION
@oblodgett @sierra-moxon 

**Please don't approve / push this change until we're ready for release.**

This is the change required to update the interactions file for 2.1.

It's a bit tricky -- the same `tar.gz` filename is currently in use for 2.0 but it has a different extracted filename (`Alliance_molecular_interactions_2.0.txt`). This PR _should_ fail until I swap out the `.tar.gz` file for the newer 2.1 version on S3. When I make that swap on the S3, the 2.0 website will temporarily have the 2.1 filename on the download page, but only until the new release goes live. I'll re-run the tests on this PR once I make the S3 swap.

I can't think of anyway around this since the interactions group requested that the _same_ filename be used for the `tar.gz` for every release. Hopefully we can replace this manual file swapping approach with the submission system for 2.2.