### PR TITLE
added property to disease entity join and tests for dateAssigned

### DIFF
--- a/src/etl/disease_etl.py
+++ b/src/etl/disease_etl.py
@@ -24,8 +24,9 @@ class DiseaseETL(ETL):
             //This is an intentional MERGE, please leave as is
             
             MERGE (dfa:Association:DiseaseEntityJoin {primaryKey:row.diseaseUniqueKey})
-                ON CREATE SET dfa.dataProvider = row.dataProvider
-                ON CREATE SET dfa.sortOrder = 1
+                ON CREATE SET dfa.dataProvider = row.dataProvider,
+                              dfa.dateAssigned = row.dateAssigned,
+                              dfa.sortOrder = 1
 
             FOREACH (rel IN CASE when row.relationshipType = 'is_marker_for' THEN [1] ELSE [] END |
                 MERGE (allele)<-[faf:IS_MARKER_FOR {uuid:row.diseaseUniqueKey}]->(d)
@@ -70,6 +71,7 @@ class DiseaseETL(ETL):
 
             MERGE (dga:Association:DiseaseEntityJoin {primaryKey:row.diseaseUniqueKey})
                 SET dga.dataProvider = row.dataProvider
+                SET dga.dateAssigned = row.dateAssigned
                 SET dga.sortOrder = 1
 
             FOREACH (rel IN CASE when row.relationshipType = 'is_marker_for' THEN [1] ELSE [] END |

--- a/src/etl/disease_etl.py
+++ b/src/etl/disease_etl.py
@@ -70,9 +70,9 @@ class DiseaseETL(ETL):
             MATCH (gene:Gene {primaryKey:row.primaryId})
 
             MERGE (dga:Association:DiseaseEntityJoin {primaryKey:row.diseaseUniqueKey})
-                SET dga.dataProvider = row.dataProvider
-                SET dga.dateAssigned = row.dateAssigned
-                SET dga.sortOrder = 1
+                SET dga.dataProvider = row.dataProvider,
+                    dga.dateAssigned = row.dateAssigned,
+                    dga.sortOrder = 1
 
             FOREACH (rel IN CASE when row.relationshipType = 'is_marker_for' THEN [1] ELSE [] END |
                 MERGE (gene)<-[fafg:IS_MARKER_FOR {uuid:row.diseaseUniqueKey}]->(d)

--- a/src/etl/helpers/disease_helper.py
+++ b/src/etl/helpers/disease_helper.py
@@ -89,6 +89,7 @@ class DiseaseHelper(object):
                 "relationshipType": diseaseAssociationType,
                 "dateProduced": dateProduced,
                 "dataProvider": dataProviderSingle,
+                "dateAssigned": diseaseRecord["dateAssigned"],
                 
                 "pubPrimaryKey": pubMedId + publicationModId,
                 

--- a/src/test/schema_node_tests.py
+++ b/src/test/schema_node_tests.py
@@ -115,7 +115,6 @@ class TestClass(object):
                             dict(node='Chromosome', prop='primaryKey'),
                             dict(node='DiseaseEntityJoin', prop='primaryKey'),
                             dict(node='DiseaseEntityJoin', prop='joinType'),
-                            dict(node='DiseaseEntityJoin', prop='dateAssigned'),
                             dict(node='DiseaseEntityJoin', prop='sortOrder'),
                             dict(node='PhenotypeEntityJoin', prop='primaryKey'),
                             dict(node='InteractionGeneJoin', prop='joinType'),

--- a/src/test/schema_node_tests.py
+++ b/src/test/schema_node_tests.py
@@ -115,6 +115,7 @@ class TestClass(object):
                             dict(node='Chromosome', prop='primaryKey'),
                             dict(node='DiseaseEntityJoin', prop='primaryKey'),
                             dict(node='DiseaseEntityJoin', prop='joinType'),
+                            dict(node='DiseaseEntityJoin', prop='dateAssigned'),
                             dict(node='DiseaseEntityJoin', prop='sortOrder'),
                             dict(node='PhenotypeEntityJoin', prop='primaryKey'),
                             dict(node='InteractionGeneJoin', prop='joinType'),

--- a/src/test/specific_tests.py
+++ b/src/test/specific_tests.py
@@ -26,6 +26,14 @@ def test_isobsolete_false():
         assert record["count"] > 0
 
 
+def test_currated_disease_associations_have_date_assigned():
+    query = "MATCH (n:DiseaseEntityJoin) WHERE NOT n.joinType IN ['implicated_via_orthology', 'biomarker_via_orthology'] AND NOT EXISTS(n.dateAssigned)" \
+            "RETURN COUNT(n) as count"
+    result = execute_transaction(query)
+    for record in result:
+        assert record["count"] == 0
+
+
 def test_species_disease_pub_gene_exists():
     query = "MATCH (s:Species)--(g:Gene)--(dg:DiseaseEntityJoin)--(pubECJ:PublicationEvidenceCodeJoin)--(p:Publication) " \
             "RETURN COUNT(p) AS count"


### PR DESCRIPTION
Hi Sierra, 

I ran this locally and it adds the dateAssigned from the JSON file being submitted. I have created one test to make sure it is there. In the future, we can write more tests.. not sure what they will be. JSON Schema validation already has the field as required so it should always exist. I am about to use this field for generating the DAF so I might run into issue which I will write tests for :). 