### PR TITLE
Removing chr from chromosomes variation etl

### DIFF
--- a/src/etl/bgi_etl.py
+++ b/src/etl/bgi_etl.py
@@ -366,6 +366,9 @@ class BGIETL(ETL):
             if 'genomeLocations' in geneRecord:
                 for genomeLocation in geneRecord['genomeLocations']:
                     chromosome = genomeLocation['chromosome']
+                    if chromosome.startswith("chr"):
+                        chromosome = chromosome[3:]
+
                     assembly = genomeLocation['assembly']
                     if chromosome not in chromosomes:
                         chromosomes[chromosome] = {"primaryKey": chromosome}

--- a/src/etl/helpers/assembly_sequence_helper.py
+++ b/src/etl/helpers/assembly_sequence_helper.py
@@ -46,11 +46,7 @@ class AssemblySequenceHelper(object):
            end = second
 
         start = start - 1
-        if chromosome.startswith("chr"):
-            chromosome_str = chromosome[3:]
+        if chromosome in self.fa:
+            return self.fa[chromosome][start:end].seq
         else:
-            chromosome_str = chromosome
-        if chromosome_str in self.fa:
-            return self.fa[chromosome_str][start:end].seq
-        else:
-            logger.warning("Chromosome " + chromosome_str + " not in assembly " + self.assembly)
+            logger.warning("Chromosome " + chromosome + " not in assembly " + self.assembly)

--- a/src/etl/variation_etl.py
+++ b/src/etl/variation_etl.py
@@ -187,6 +187,12 @@ class VariationETL(ETL):
 
         assemblies = {}
         for alleleRecord in variant_data['data']:
+            chromosome = alleleRecord["chromosome"]
+            if chromosome.startswith("chr"):
+                chromosome_str = chromosome[3:]
+            else:
+                chromosome_str = chromosome
+
             assembly = alleleRecord["assembly"]
             if assembly not in assemblies:
                context_info = ContextInfo()
@@ -207,8 +213,8 @@ class VariationETL(ETL):
             if alleleRecord.get('start') != "" and alleleRecord.get('end') != "":
 
                 # not insertion
-                if SOTermId != "SO:0000667" and alleleRecord.get('chromosome') != "Unmapped_Scaffold_8_D1580_D1567":
-                    genomicReferenceSequence = assemblies[assembly].getSequence(alleleRecord.get('chromosome'),
+                if SOTermId != "SO:0000667" and chromosome_str != "Unmapped_Scaffold_8_D1580_D1567":
+                    genomicReferenceSequence = assemblies[assembly].getSequence(chromosome_str,
                                                                                 alleleRecord.get('start'),
                                                                                 alleleRecord.get('end'))
 
@@ -228,11 +234,11 @@ class VariationETL(ETL):
                 if leftPaddingStart < 1:
                     leftPaddingStart = 1
 
-                paddingLeft = assemblies[assembly].getSequence(alleleRecord.get('chromosome'),
+                paddingLeft = assemblies[assembly].getSequence(chromosome_str,
                                                                leftPaddingStart,
                                                                start)
                 rightPaddingEnd = end + paddingWidth
-                paddingRight = assemblies[assembly].getSequence(alleleRecord.get('chromosome'),
+                paddingRight = assemblies[assembly].getSequence(chromosome_str,
                                                                 end,
                                                                 rightPaddingEnd)
             counter = counter + 1
@@ -290,7 +296,7 @@ class VariationETL(ETL):
             variant_genomic_location_dataset = {
                 "variantId": variantUUID,
                 "assembly": alleleRecord.get('assembly'),
-                "chromosome": alleleRecord.get('chromosome'),
+                "chromosome": chromosome_str,
                 "start": alleleRecord.get('start'),
                 "end": alleleRecord.get('end')
 
@@ -313,4 +319,4 @@ class VariationETL(ETL):
                 crossReferences = []
 
         if counter > 0:
-            yield [variants,variant_genomic_locations,variant_so_terms, crossReferences]
+            yield [variants, variant_genomic_locations, variant_so_terms, crossReferences]


### PR DESCRIPTION
I have made the decision to never have the chr prefix on chromosome names. This would be nice to keep consistent throughout the Alliance project. I have not run this with the full dataset.