### PR TITLE
fixing the missing strand AGR-682

### DIFF
--- a/src/etl/bgi_etl.py
+++ b/src/etl/bgi_etl.py
@@ -383,7 +383,7 @@ class BGIETL(ETL):
                     else:
                         end = None
 
-                    if 'strand' in geneRecord['genomeLocations']:
+                    if 'strand' in genomeLocation:
                         strand = genomeLocation['strand']
                     else:
                         strand = None


### PR DESCRIPTION
The issues is that the strand was not making its way through with the genomeLocation information. It looked clear to me that the code just needed a small adjustment