### PR TITLE
Gene descriptions - new files for MGI and expression blacklist fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       - NEO4J_HOST=neo4j
       - NET=production
       - ALLIANCE_RELEASE=2.3.0
-      - FMS_API_URL=https://fmsdev.alliancegenome.org
-      - DOWNLOAD_HOST=downloaddev.alliancegenome.org
+      - FMS_API_URL=https://fms.alliancegenome.org
+      - DOWNLOAD_HOST=download.alliancegenome.org
       - API_KEY=${API_KEY}
     entrypoint:
       - python3
@@ -64,8 +64,8 @@ services:
      - NEO4J_HOST=neo4j
      - NET=production
      - ALLIANCE_RELEASE=2.3.0
-     - FMS_API_URL=https://fmsdev.alliancegenome.org
-     - DOWNLOAD_HOST=downloaddev.alliancegenome.org
+     - FMS_API_URL=https://fms.alliancegenome.org
+     - DOWNLOAD_HOST=download.alliancegenome.org
      - API_KEY=${API_KEY}
     entrypoint:
       - python3
@@ -91,8 +91,8 @@ services:
      - NEO4J_HOST=neo4j
      - NET=production
      - ALLIANCE_RELEASE=2.3.0
-     - FMS_API_URL=https://fmsdev.alliancegenome.org
-     - DOWNLOAD_HOST=downloaddev.alliancegenome.org
+     - FMS_API_URL=https://fms.alliancegenome.org
+     - DOWNLOAD_HOST=download.alliancegenome.org
      - API_KEY=${API_KEY}
     entrypoint:
       - python3
@@ -118,8 +118,8 @@ services:
      - NEO4J_HOST=neo4j
      - NET=production
      - ALLIANCE_RELEASE=2.3.0
-     - FMS_API_URL=https://fmsdev.alliancegenome.org
-     - DOWNLOAD_HOST=downloaddev.alliancegenome.org
+     - FMS_API_URL=https://fms.alliancegenome.org
+     - DOWNLOAD_HOST=download.alliancegenome.org
      - API_KEY=${API_KEY}
     entrypoint:
       - pytest

--- a/gene_descriptions.yml
+++ b/gene_descriptions.yml
@@ -555,7 +555,7 @@ expression_sentences_options:
     - "ZFA:0001094" # whole organism
     - "ZFA:0000037" # anatomical structure
     - "ZFA:0000292" # surface structure
-    - "ZFA:000149" # cavitated compound organ
+    - "ZFA:0001490" # cavitated compound organ
     - "EMAPA:25765" # mouse
     - "EMAPA:35949" # organ
     - "EMAPA:36040" # conceptus

--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -1,11 +1,11 @@
 USING_PICKLE: false
 DEBUG: false
-DOWNLOAD_HOST: "downloaddev.alliancegenome.org"
+DOWNLOAD_HOST: "download.alliancegenome.org"
 GENERATE_REPORTS: false
 ALLIANCE_RELEASE: "0.0.0"
 NEO4J_HOST: "localhost"
 NEO4J_PORT: 7687
-FMS_API_URL: "https://fmsdev.alliancegenome.org"
+FMS_API_URL: "https://fms.alliancegenome.org"
 TEST_SET: false
 AWS_ACCESS_KEY: ""
 AWS_SECRET_KEY: ""


### PR DESCRIPTION
- new BGI file for MGI
- AGR-1729 bug fixed (expression term missing from blacklist)
- changed docker-compose.yml and default_env_vars.yml to point to FMSprod instead of FMSdev as default option for the loader