### PR TITLE
fix: graylist terms added to blacklist

### DIFF
--- a/gene_descriptions.yml
+++ b/gene_descriptions.yml
@@ -568,6 +568,10 @@ expression_sentences_options:
     - "EMAPA:35178" # body fluid or substance
     - "EMAPA:35868" # tissue
     - "EMAPA:16262" # oral region
+    - "EMAPA:16039" # embryo
+    - "EMAPA:31858" # head
+    - "EMAPA:18425" # gland
+    - "FBbt:00000001" # organism
     - "WBbt:0005758" # hermaphrodite-specific
     - "WBbt:0007849" # hermaphrodite
     - "WBbt:0005738" # body region


### PR DESCRIPTION
graylist terms should be in the blacklist to avoid picking them as common ancestors while trimming

