### PR TITLE
Updates for 3.0.0 interactions.

### DIFF
--- a/src/aggregate_loader.py
+++ b/src/aggregate_loader.py
@@ -100,7 +100,7 @@ class AggregateLoader(object):
             'GAF': GOAnnotETL,
             'GeoXref': GeoXrefETL,
             'GeneDiseaseOrtho': GeneDiseaseOrthoETL,
-            'Interactions': MolecularInteractionETL,
+            'INTERACTION-MOL': MolecularInteractionETL,
             'GeneDescriptions': GeneDescriptionsETL,
             'VEP': VEPETL
         }
@@ -131,7 +131,7 @@ class AggregateLoader(object):
             ['GAF'],  # Locks Genes
             ['GeoXref'],  # Locks Genes
             ['GeneDiseaseOrtho'],
-            ['Interactions'],
+            ['INTERACTION-MOL'],
             ['Closure'],
             ['GeneDescriptions'],
             ['VEP']

--- a/src/config/default.yml
+++ b/src/config/default.yml
@@ -72,7 +72,7 @@ Closure:
   - WBPhenotype
   - MP
   - HP
-Interactions: [MolecularInteraction]
+INTERACTION-MOL: [COMBINED]
 GeneDescriptions: [FB, SGD, WB, ZFIN, RGD, MGI, HUMAN]
 VEP: [FB, WB, ZFIN, RGD, MGI]
 

--- a/src/config/develop.yml
+++ b/src/config/develop.yml
@@ -72,8 +72,8 @@ Closure:
   - WBPhenotype
   - MP
   - HP
-Interactions: [MolecularInteraction]
-GeneDescriptions: [FB, SGD, WB, ZFIN, RGD, MGI, HUMAN]
+INTERACTION-MOL: [COMBINED]
+gitGeneDescriptions: [FB, SGD, WB, ZFIN, RGD, MGI, HUMAN]
 VEP: [FB, WB, ZFIN, RGD, MGI]
 
 # Loader configuration values are below.

--- a/src/config/local_submission.json
+++ b/src/config/local_submission.json
@@ -56,13 +56,6 @@
                 "uploadDate": 1522181475376
             },
             {
-                "dataType": {"id":"1234", "name":"Interactions"},
-                "dataSubType": {"id":"1234", "name":"MolecularInteraction"},
-                "s3Path": "2.3.0/INTERACTION/COMBINED/INTERACTION_COMBINED_2.tar.gz",
-                "tempExtractedFile": "output/alliance_molecular_interactions.txt",
-                "uploadDate": 1522181475376
-            },
-            {
                 "dataType": {"id":"1234", "name":"FASTA"},
                 "dataSubType": {"id":"1234", "name":"Rnor60"},
                 "s3Path": "1.0.0.8/FASTA/Rnor60/1.0.0.8_FASTA_Rnor60_1.null",

--- a/src/config/test.yml
+++ b/src/config/test.yml
@@ -72,7 +72,7 @@ Closure:
   - WBPhenotype
   - MP
   - HP
-Interactions: [MolecularInteraction]
+INTERACTION-MOL: [COMBINED]
 GeneDescriptions: [FB, SGD, WB, ZFIN, RGD, MGI, HUMAN]
 VEP: [FB, WB, ZFIN, RGD, MGI]
 

--- a/src/config/validation.yml
+++ b/src/config/validation.yml
@@ -118,9 +118,9 @@ Closure:
     - WBPhenotype
     - MP
     - HP
-Interactions:
+INTERACTION-MOL:
   type: list
-  allowed: [MolecularInteraction]
+  allowed: [COMBINED]
 GeneDescriptions:
   type: list
   allowed: [FB, SGD, WB, ZFIN, RGD, MGI, HUMAN]

--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -401,7 +401,7 @@ class GeneDescriptionsETL(ETL):
             logger.debug(file_to_upload)
             logger.debug(headers)
             logger.debug('Uploading gene description files to FMS ' + context_info.env['FMS_API_URL'])
-            response = requests.post(context_info.env['FMS_API_URL'] + '/api/data/submit/', files=file_to_upload, headers=headers)
+            response = requests.post(context_info.env['FMS_API_URL'] + '/api/data/submit', files=file_to_upload, headers=headers)
             logger.info(response.text)
 
     def save_descriptions_report_files(self, data_provider, json_desc_writer, context_info, gd_data_manager):

--- a/src/etl/molecular_interaction_etl.py
+++ b/src/etl/molecular_interaction_etl.py
@@ -86,7 +86,9 @@ class MolecularInteractionETL(ETL):
 
     def _load_and_process_data(self):
 
-        filepath = self.data_type_config.get_single_filepath()
+        # filepath = self.data_type_config.get_single_filepath()
+        # Temporary fix for 3.0 release.
+        filepath = 'tmp/alliance_molecular_interactions.tsv'
 
         commit_size = self.data_type_config.get_neo4j_commit_size()
         batch_size = self.data_type_config.get_generator_batch_size()
@@ -331,6 +333,9 @@ class MolecularInteractionETL(ETL):
             except IndexError:
                 return None
 
+            if individual_entry.startswith('uniprotkb:'):
+                individual_entry = individual_entry.split('-')[0]
+
             prefixed_identifier = None
 
             if entry_stripped.startswith('WB'): # TODO implement regex for WB / FB gene identifiers.
@@ -379,6 +384,8 @@ class MolecularInteractionETL(ETL):
         total_interactions_loaded_count = 0
 
         # database_linkout_set = set()
+
+        logger.info('Attempting to open {}'.format(filepath))
 
         with open(filepath, 'r', encoding='utf-8') as tsvin:
             tsvin = csv.reader(tsvin, delimiter='\t')


### PR DESCRIPTION
Temporarily hardcoding the extracted interactions filename.

The current data_config approach doesn't allow us to update the filepath once the compressed file is uncompressed. There will need to be a minor rewrite of handling .tar.gz files in the near future in order to remove the hardcoded filename from the molecular interactions ETL. I'll be making a JIRA ticket for 3.1.