### PR TITLE
patched version of GD software to fix SGD GAF file on the fly

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ jsonschema
 pyyaml
 urllib3==1.24.2
 xmltodict
-git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.0.0#egg=genedescriptions
+git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.0.1#egg=genedescriptions
 ontobio==1.11.4
 boto3
 coloredlogs


### PR DESCRIPTION
Changed version of gene description software - Added patch to fix wrong SGD GAF file on the fly

Change in the GD code: 
- Add missing underscore to qualifiers in GAF files.
- SGD is working to fix the bug at the source but this patch avoids to add further delay to 3.0 release

