### PR TITLE
fix(generic_ontology): filter out gci axioms

### DIFF
--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -290,9 +290,8 @@ class GeneDescriptionsETL(ETL):
             self.add_neo_term_to_ontobio_ontology_if_not_exists(
                 terms_pair["term2.primaryKey"], terms_pair["term2.name"], terms_pair["term2.type"],
                 terms_pair["term2.isObsolete"], ontology)
-            if terms_pair["term1.primaryKey"] != "FBbt:10000000":
-                ontology.add_parent(terms_pair["term1.primaryKey"], terms_pair["term2.primaryKey"],
-                                    relation="subClassOf" if terms_pair["rel_type"] == "IS_A" else "BFO:0000050")
+            ontology.add_parent(terms_pair["term1.primaryKey"], terms_pair["term2.primaryKey"],
+                                relation="subClassOf" if terms_pair["rel_type"] == "IS_A" else "BFO:0000050")
         if data_type == DataType.EXPR and provider == "MGI":
             self.add_neo_term_to_ontobio_ontology_if_not_exists("EMAPA_ARTIFICIAL_NODE:99999",
                                                                 "embryo",

--- a/src/etl/generic_ontology_etl.py
+++ b/src/etl/generic_ontology_etl.py
@@ -195,38 +195,42 @@ class GenericOntologyETL(ETL):
             if o_is_as is not None:
                 if isinstance(o_is_as, (list, tuple)):
                     for isa in o_is_as:
-                        isa_without_name = isa.split(' ')[0].strip()
-                        isas_dict_to_append = {
-                            'oid' : ident,
-                            'isa' : isa_without_name}
-                        isas.append(isas_dict_to_append)
+                        if 'gci_filler=' not in isa:
+                            isa_without_name = isa.split(' ')[0].strip()
+                            isas_dict_to_append = {
+                                'oid' : ident,
+                                'isa' : isa_without_name}
+                            isas.append(isas_dict_to_append)
                 else:
-                    isa_without_name = o_is_as.split(' ')[0].strip()
-                    isas_dict_to_append = {'oid' : ident,
-                                           'isa' : isa_without_name}
-                    isas.append(isas_dict_to_append)
+                    if 'gci_filler=' not in o_is_as:
+                        isa_without_name = o_is_as.split(' ')[0].strip()
+                        isas_dict_to_append = {'oid' : ident,
+                                               'isa' : isa_without_name}
+                        isas.append(isas_dict_to_append)
 
             # part_of processing
             relations = line.get('relationship')
             if relations is not None:
                 if isinstance(relations, (list, tuple)):
                     for partof in relations:
-                        relationship_descriptors = partof.split(' ')
+                        if 'gci_filler=' not in partof:
+                            relationship_descriptors = partof.split(' ')
+                            o_part_of = relationship_descriptors[0]
+                            if o_part_of == 'part_of':
+                                partof_dict_to_append = {
+                                    'oid': ident,
+                                    'partof': relationship_descriptors[1]
+                                }
+                                partofs.append(partof_dict_to_append)
+                else:
+                    if 'gci_filler=' not in relations:
+                        relationship_descriptors = relations.split(' ')
                         o_part_of = relationship_descriptors[0]
                         if o_part_of == 'part_of':
                             partof_dict_to_append = {
-                                'oid': ident,
-                                'partof': relationship_descriptors[1]
-                            }
+                                'oid' : ident,
+                                'partof' : relationship_descriptors[1]}
                             partofs.append(partof_dict_to_append)
-                else:
-                    relationship_descriptors = relations.split(' ')
-                    o_part_of = relationship_descriptors[0]
-                    if o_part_of == 'part_of':
-                        partof_dict_to_append = {
-                            'oid' : ident,
-                            'partof' : relationship_descriptors[1]}
-                        partofs.append(partof_dict_to_append)
 
             definition = line.get('def')
             if definition is None:


### PR DESCRIPTION
some GCI (general concept inclusion) axioms are wrongly interpreted as conventional relations and this is causing loops on FBBT root terms. This PR adds a filter to avoid loading them from the Alliance custom obo loader and removes the code previously added to the gene description etl to manage the loops.


