### PR TITLE
Add Association Label to Publication Join

### DIFF
--- a/src/etl/phenotype_etl.py
+++ b/src/etl/phenotype_etl.py
@@ -45,7 +45,7 @@ class PhenoTypeETL(ETL):
                  pubf.pubMedUrl = row.pubMedUrl
            
                        //MERGE (pubf)-[pe:EVIDENCE]-(pa)
-           CREATE (pubEJ:PublicationJoin {primaryKey:row.pecjPrimaryKey})
+           CREATE (pubEJ:PublicationJoin:Association {primaryKey:row.pecjPrimaryKey})
              SET pubEJ.joinType = 'pub_evidence_code_join'
 
             CREATE (pubf)-[pubfpubEJ:ASSOCIATION {uuid:row.pecjPrimaryKey}]->(pubEJ)


### PR DESCRIPTION
The Publication Joins were getting made two ways one with the ":Association" label and one without. I don't think this effected anything but caused an issue when generating the stats. I made a fix in the code that creates the db-summary that got around this issue but didn't fully fix it. I think this change will help. 

As the MERGE had the association label but the CREATE did not I am assuming that it just merged in the ":Association" label for the ones that got merged instead of creating a new node. 

This also makes it match the publicationJoin nodes in the gene_disease_ortho_etl. 