### PR TITLE
AGR-2364

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ reload:
 
 reload_test: 
 	docker-compose up -d neo4j
-	docker-compose down -v
+	docker-compose down
 	docker-compose up -d neo4j
 	sleep 10
 	docker build -t agrdocker/agr_loader_run:latest .

--- a/src/files/s3_file.py
+++ b/src/files/s3_file.py
@@ -24,7 +24,7 @@ class S3File():
         """Download"""
 
         if not os.path.exists(os.path.dirname(os.path.join(self.savepath, self.filename))):
-            self.logger.info("Making temp file storage: %s", self.savepath)
+            self.logger.info("Making temp file storage: %s", os.path.dirname(os.path.join(self.savepath, self.filename)))
             os.makedirs(os.path.dirname(os.path.join(self.savepath, self.filename)))
 
         url = self.download_url
@@ -46,7 +46,7 @@ class S3File():
         """Download New"""
 
         if not os.path.exists(os.path.dirname(os.path.join(self.savepath, self.filename))):
-            self.logger.debug("Making temp file storage: %s", self.savepath)
+            self.logger.debug("Making temp file storage: %s", os.path.dirname(os.path.join(self.savepath, self.filename)))
 
             # Our little retry loop. Implemented due to speed-related writing errors.
             # TODO Replace / update with "tenacity" module.


### PR DESCRIPTION
Basically -v on the docker-compose down was deleting the shared data volume for reload_test. So removed this. (Not sure if we need to do this with reload as well, someone else who knows the project better can make that call.)