### PR TITLE
Revert human

### DIFF
--- a/src/etl/bgi_etl.py
+++ b/src/etl/bgi_etl.py
@@ -427,6 +427,12 @@ class BGIETL(ETL):
         release = None
         counter = 0
 
+        # small hack to fix gene descriptions while we discuss what to do here w/re to conversion from using
+        # meta data in the input files to using subType config version.
+
+        if data_provider == 'HUMAN':
+            data_provider = 'RGD'
+
         self.data_providers_process(gene_data)
         load_key = date_produced + data_provider + "_BGI"
 

--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -51,7 +51,7 @@ class GeneDescriptionsETL(ETL):
 
     get_all_genes_human_query = """
         MATCH (g:Gene)
-        WHERE g.dataProvider = {parameter} AND g.primaryKey CONTAINS "HGNC:"
+        WHERE g.primaryKey CONTAINS "HGNC:"
         RETURN g.primaryKey, g.symbol"""
 
     get_gene_disease_annot_query = """
@@ -210,8 +210,7 @@ class GeneDescriptionsETL(ETL):
         """Create generators."""
         gene_prefix = ""
         if data_provider == "HUMAN":
-            return_set = Neo4jHelper.run_single_parameter_query(self.get_all_genes_human_query,
-                                                                "RGD")
+            return_set = Neo4jHelper.run_single_query(self.get_all_genes_human_query)
             gene_prefix = "RGD:"
         else:
             return_set = Neo4jHelper.run_single_parameter_query(self.get_all_genes_query,

--- a/src/test/specific_tests.py
+++ b/src/test/specific_tests.py
@@ -146,39 +146,71 @@ def test_spell_cross_ref_type():
         assert record["counter"] < 1
 
 
-def test_gene_has_automated_description():
-    """Test Gene has Automated Description"""
+def test_genes_have_automated_description():
+    """Test Genes Have Automated Description"""
 
-    query = """MATCH (g:Gene) where g.primaryKey = 'ZFIN:ZDB-GENE-030131-4430'
-               AND g.automatedGeneSynopsis IS NOT NULL
+    query = """MATCH (g:Gene) where g.primaryKey IN ['SGD:S000002536', 'FB:FBgn0027655', 'FB:FBgn0045035', 'RGD:68337', 
+                                                     'RGD:2332', 'MGI:96067', 'MGI:88388', 'MGI:107202', 'MGI:106658',
+                                                     'MGI:105043', 'HGNC:4851', 'ZFIN:ZDB-GENE-990415-131',
+                                                     'HGNC:1884', 'HGNC:795', 'HGNC:11291','RGD:1593265',
+                                                     'RGD:1559787', 'ZFIN:ZDB-GENE-050517-20',
+                                                     'ZFIN:ZDB-GENE-990415-131', 'ZFIN:ZDB-GENE-030131-4430']
+               AND g.automatedGeneSynopsis IS NULL
                RETURN count(g) AS counter"""
     result = execute_transaction(query)
     for record in result:
-        assert record["counter"] == 1
+        assert record["counter"] == 0
 
 
-def test_gene_has_all_three_automated_description_components():
-    """Test Gene has All Three Automated Description Components"""
+def test_at_least_one_gene_has_go_description():
+    """Test At Least One Gene Has GO Description"""
 
     query = """MATCH (g:Gene)
-               WHERE g.primaryKey IN ['SGD:S000002536', 'FB:FBgn0027655',
-                                      'FB:FBgn0045035','RGD:68337', 'RGD:2332',
-                                      'MGI:96067', 'MGI:88388', 'MGI:107202', 'MGI:106658',
-                                      'MGI:105043', 'HGNC:4851', 'ZFIN:ZDB-GENE-990415-131',
-                                      'HGNC:1884', 'HGNC:795', 'HGNC:11291','RGD:1593265',
-                                      'RGD:1559787', 'ZFIN:ZDB-GENE-050517-20',
-                                      'ZFIN:ZDB-GENE-990415-131']
-               AND (NOT (g.automatedGeneSynopsis =~ '.*xhibits.*'
-                         OR g.automatedGeneSynopsis =~ '.*nvolved in.*'
-                         OR g.automatedGeneSynopsis =~ '.*ocalizes to.*'
-                         OR g.automatedGeneSynopsis =~ '.*redicted to have.*'
-                         OR g.automatedGeneSynopsis =~ '.*redicted to be involved in.*')
-                    OR NOT (g.automatedGeneSynopsis =~ '.*sed to study.*'
-                            OR g.automatedGeneSynopsis =~ '.*mplicated in.*'))
-              RETURN COUNT(g) AS counter"""
+               WHERE (g.automatedGeneSynopsis =~ '.*xhibits.*' OR g.automatedGeneSynopsis =~ '.*nvolved in.*'
+                      OR g.automatedGeneSynopsis =~ '.*ocalizes to.*' 
+                      OR g.automatedGeneSynopsis =~ '.*redicted to have.*'
+                      OR g.automatedGeneSynopsis =~ '.*redicted to be involved in.*' 
+                      OR g.automatedGeneSynopsis =~ '.*redicted to localize to.*')
+               RETURN COUNT(g) AS counter"""
     result = execute_transaction(query)
     for record in result:
-        assert record["counter"] == 0
+        assert record["counter"] > 0
+
+
+def test_at_least_one_gene_has_disease_description():
+    """Test At Least One Gene Has Disease Description"""
+
+    query = """MATCH (g:Gene)
+               WHERE (g.automatedGeneSynopsis =~ '.*sed to study.*' 
+                      OR g.automatedGeneSynopsis =~ '.*mplicated in.*'
+                      OR g.automatedGeneSynopsis =~ '.*iomarker of.*')
+               RETURN COUNT(g) AS counter"""
+    result = execute_transaction(query)
+    for record in result:
+        assert record["counter"] > 0
+
+
+def test_at_least_one_gene_has_expression_description():
+    """Test At Least One Gene Has Expression Description"""
+
+    query = """MATCH (g:Gene)
+               WHERE (g.automatedGeneSynopsis =~ '.*s expressed in.*'
+                      OR g.automatedGeneSynopsis =~ '.*s enriched in.*')
+               RETURN COUNT(g) AS counter"""
+    result = execute_transaction(query)
+    for record in result:
+        assert record["counter"] > 0
+
+
+def test_at_least_one_gene_has_orthology_description():
+    """Test At Least One Gene Has Orthology Description"""
+
+    query = """MATCH (g:Gene)
+               WHERE g.automatedGeneSynopsis =~ '.*rthologous to.*'
+               RETURN COUNT(g) AS counter"""
+    result = execute_transaction(query)
+    for record in result:
+        assert record["counter"] > 0
 
 
 def test_nephrogenic_diabetes_insipidus_has_at_least_one_gene():


### PR DESCRIPTION
This PR reverts the gene dataProvider field in neo for human genes from "HUMAN" back to "RGD". This restores human gene descriptions. Just to be extra safe, the GD ETL now retrieves human genes from neo without using the dataProvider field, and there are additional unit tests.