### PR TITLE
Currently tested by querying the database query interface AGR-2294

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,3 @@ aws_secret_access_key = `
 - Proceed with the appropriate make commands as usual.
 - Reminder: this process needs to be repeated every time you get an error like this (usually ~ every 12 hours):
 `Error response from daemon: pull access denied for 100225593120.dkr.ecr.us-east-1.amazonaws.com/agr_neo4j_env, repository does not exist or may require 'docker login': denied: Your authorization token has expired. Reauthenticate and try again.`
-

--- a/src/etl/do_etl.py
+++ b/src/etl/do_etl.py
@@ -6,6 +6,7 @@ from ontobio import OntologyFactory
 
 from etl import ETL
 from etl.helpers import ETLHelper
+from etl.helpers import OBOHelper
 from transactors import CSVTransactor
 from transactors import Neo4jTransactor
 
@@ -108,6 +109,7 @@ class DOETL(ETL):
         """Get Generators."""
         ont = OntologyFactory().create(filepath)
         parsed_line = ont.graph.copy().node
+        OBOHelper.add_metadata_to_neo(filepath)
 
         do_term_list = []
         do_isas_list = []

--- a/src/etl/ecomap_etl.py
+++ b/src/etl/ecomap_etl.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing
 
 from etl import ETL
+from etl.helpers import OBOHelper
 from files import TXTFile
 from transactors import CSVTransactor
 from transactors import Neo4jTransactor
@@ -66,6 +67,8 @@ class ECOMAPETL(ETL):
     def get_generators(self, filepath, batch_size):
         """Create Generator."""
         data = TXTFile(filepath).get_data()
+        OBOHelper.add_metadata_to_neo(filepath)
+
         eco_maps = []
 
         for line in data:

--- a/src/etl/generic_ontology_etl.py
+++ b/src/etl/generic_ontology_etl.py
@@ -126,6 +126,8 @@ class GenericOntologyETL(ETL):
 
     def get_generators(self, filepath, batch_size):  # noqa
         """Get Generators."""
+
+        OBOHelper.add_metadata_to_neo(filepath)
         o_data = TXTFile(filepath).get_data()
         parsed_line = OBOHelper.parse_obo(o_data)
 

--- a/src/etl/go_etl.py
+++ b/src/etl/go_etl.py
@@ -3,6 +3,7 @@
 import logging
 from ontobio import OntologyFactory
 from etl import ETL
+from etl.helpers import OBOHelper
 from transactors import CSVTransactor, Neo4jTransactor
 
 
@@ -120,6 +121,8 @@ class GOETL(ETL):
 
     def get_generators(self, filepath, batch_size):  # noqa
         """Get Generators."""
+
+        OBOHelper.add_metadata_to_neo(filepath)
         ont = OntologyFactory().create(filepath)
         parsed_line = ont.graph.copy().node
 

--- a/src/etl/helpers/obo_helper.py
+++ b/src/etl/helpers/obo_helper.py
@@ -1,16 +1,50 @@
 """OBO Helper."""
 
 import logging
+import json
+from collections import defaultdict
 
 from ontobio import OntologyFactory
 from .etl_helper import ETLHelper
-
+from .neo4j_helper import Neo4jHelper
 
 class OBOHelper():
     """OBO Helper."""
 
     logger = logging.getLogger(__name__)
     etlh = ETLHelper()
+
+    @staticmethod
+    def add_metadata_to_neo(filepath):
+        """Gets header information and places it adds node into Neo"""
+
+        header = OBOHelper.get_header(filepath)
+        header["primaryKey"] = header["ontology"]
+        fields = []
+        for k in header:
+            fields.append(k + ": " + json.dumps(header[k]))
+        Neo4jHelper().run_single_query("CREATE (o:OntologyFileMetadata {" + ",".join(fields) + "})")
+
+    @staticmethod
+    def get_header(filepath):
+        """Retrieve header information into dictionary"""
+
+        header = defaultdict(list)
+        with open(filepath, 'r') as f:
+            for line in f:
+                if not line.strip() or line[0] is "#":
+                    break
+                [k, v] = line.rstrip().split(": ", 1)
+                camel_k = ''.join(x.capitalize() or '-' for x in k.split('-'))
+                camel_k = camel_k[0].lower() + camel_k[1:]
+                header[camel_k].append(str(v.replace('\"',"'")))
+
+        for k in header:
+            v = header[k]
+            if len(v) == 1:
+                header[k] = v[0]
+
+        return header
 
     def get_data(self, filepath):  # noqa
         """Get Data."""

--- a/src/etl/mi_etl.py
+++ b/src/etl/mi_etl.py
@@ -105,6 +105,7 @@ class MIETL(ETL):
     def get_generators(self, filepath):
         """Create Genrators"""
 
+        OBOHelper.add_metadata_to_neo(filepath)
         o_data = TXTFile(filepath).get_data()
         parsed_line = OBOHelper.parse_obo(o_data)
 

--- a/src/etl/so_etl.py
+++ b/src/etl/so_etl.py
@@ -5,6 +5,7 @@ import logging
 
 from itertools import islice, chain, tee
 from etl import ETL
+from etl.helpers import OBOHelper
 from files import TXTFile
 from transactors import CSVTransactor
 from transactors import Neo4jTransactor
@@ -48,6 +49,8 @@ class SOETL(ETL):
 
     def get_generators(self, filepath):
         """Get Generators."""
+
+        OBOHelper.add_metadata_to_neo(filepath)
         data = TXTFile(filepath).get_data()
         so_list = []
         for current_line, next_line in self.get_current_next(data):


### PR DESCRIPTION
This pull request adds code to pull the metadata out of the header and place it into Nodes with the label OntologyFileMetadata for each ontology file. The design is such that it transforms fields such as "release-version" to camelcase as that is what we use in our database and that Neo4J doesn't allow "-"s in the field names. Althought this is pulling all the fields through they don't all have to be used. As more fields are standardized between the Ontology files the more fields we will be able to take advantage of. That being said the code won't have to change if we want to use more fields as they are being pulled in if they are in the header.

I have tested this by running it locally and querying the Neo4J interface. To me it looks correct. 