### PR TITLE
feat(gene_descriptions): do not prettify json files

### DIFF
--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -524,7 +524,6 @@ class GeneDescriptionsETL(ETL):
         file_name = self.cur_date + "_" + data_provider
         file_path = os.path.join("tmp", file_name)
         json_desc_writer.write_json(file_path=file_path + ".json",
-                                    pretty=True,
                                     include_single_gene_stats=True,
                                     data_manager=gd_data_manager)
         json_desc_writer.write_plain_text(file_path=file_path + ".txt")


### PR DESCRIPTION
- curators no longer need to open json files directly thanks to the report tool
- some prettified json files are too large and make the report tool crash when decompressing them

