### PR TITLE
AGR-2528 - Changed aws cli usage from local install to docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_BUILD_TAG=latest
 
 registry-docker-login:
 ifneq ($(shell echo ${REG} | egrep "ecr\..+\.amazonaws\.com"),)
-	@$(eval DOCKER_LOGIN_CMD=aws)
+	@$(eval DOCKER_LOGIN_CMD=docker run --rm -it -v ~/.aws:/root/.aws amazon/aws-cli)
 ifneq (${AWS_PROFILE},)
 	@$(eval DOCKER_LOGIN_CMD=${DOCKER_LOGIN_CMD} --profile ${AWS_PROFILE})
 endif


### PR DESCRIPTION
Minor change in `Makefile`, replacing usage of locally installed aws cli with amazon-provided docker container, in order to support flybase machines (which only allow aws cli to be installed through pip virtualenv, causing conflicts).