### PR TITLE
fix(ontobio): using a patched version of ontobio to exclude GO rule 26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ urllib3==1.24.2
 xmltodict
 git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.0#egg=genedescriptions
 git+https://github.com/alliance-genome/agr_file_generator.git@8b47011
-ontobio==1.20.0
+git+https://github.com/valearna/ontobio
 boto3
 coloredlogs
 verboselogs


### PR DESCRIPTION
GO rule 26 was removing IBA annotations from the GAF files used to generate gene descriptions. This PR points to a patched version of ontobio that excludes that specific rule.