### PR TITLE
Added missing 'is active in' template for GOCC sentences

### DIFF
--- a/gene_descriptions.yml
+++ b/gene_descriptions.yml
@@ -823,6 +823,20 @@ go_sentences_options:
                 prefix: "is"
                 postfix: ""
         - aspect: C
+          group: EXPERIMENTAL
+          qualifier: "is_active_in"
+          prefix: "is active in"
+          postfix: ""
+          special_cases:
+              - id: 1
+                match_regex: "intracellular$"
+                prefix: "is"
+                postfix: ""
+              - id: 2
+                match_regex: ".*component of.*"
+                prefix: "is"
+                postfix: ""
+        - aspect: C
           group: HIGH_THROUGHPUT_EXPERIMENTAL
           qualifier: "located_in"
           prefix: "located in"
@@ -851,6 +865,20 @@ go_sentences_options:
                 prefix: "is"
                 postfix: ""
         - aspect: C
+          group: HIGH_THROUGHPUT_EXPERIMENTAL
+          qualifier: "is_active_in"
+          prefix: "is active in"
+          postfix: ""
+          special_cases:
+              - id: 1
+                match_regex: "intracellular$"
+                prefix: "is"
+                postfix: ""
+              - id: 2
+                match_regex: ".*component of.*"
+                prefix: "is"
+                postfix: ""
+        - aspect: C
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "located_in"
           prefix: "predicted to be located in"
@@ -868,6 +896,20 @@ go_sentences_options:
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "part_of"
           prefix: "predicted to be part of"
+          postfix: ""
+          special_cases:
+              - id: 1
+                match_regex: "intracellular$"
+                prefix: "predicted to be "
+                postfix: ""
+              - id: 2
+                match_regex: ".*component of.*"
+                prefix: "predicted to be"
+                postfix: ""
+        - aspect: C
+          group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
+          qualifier: "is_active_in"
+          prefix: "predicted to be active in"
           postfix: ""
           special_cases:
               - id: 1
@@ -907,6 +949,20 @@ go_sentences_options:
                 prefix: "predicted to be"
                 postfix: ""
         - aspect: C
+          group: INFERRED_BY_CURATORS_AND_AUTHORS
+          qualifier: "is_active_in"
+          prefix: "predicted to be active in"
+          postfix: ""
+          special_cases:
+              - id: 1
+                match_regex: "intracellular$"
+                prefix: "predicted to be "
+                postfix: ""
+              - id: 2
+                match_regex: ".*component of.*"
+                prefix: "predicted to be"
+                postfix: ""
+        - aspect: C
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "located_in"
           prefix: "predicted to be located in"
@@ -924,6 +980,20 @@ go_sentences_options:
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "part_of"
           prefix: "predicted to be part of"
+          postfix: ""
+          special_cases:
+              - id: 1
+                match_regex: "intracellular$"
+                prefix: "predicted to be "
+                postfix: ""
+              - id: 2
+                match_regex: ".*component of.*"
+                prefix: "predicted to be"
+                postfix: ""
+        - aspect: C
+          group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
+          qualifier: "is_active_in"
+          prefix: "predicted to be active in"
           postfix: ""
           special_cases:
               - id: 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ jsonschema
 PyYAML>=5.1
 urllib3==1.24.2
 xmltodict
-git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.0#egg=genedescriptions
+git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.3#egg=genedescriptions
 git+https://github.com/alliance-genome/agr_file_generator.git@8b47011a14d9e79d13cf9239fe0cf63c54bc9b87
-git+https://github.com/valearna/ontobio
+ontobio==1.20.0
 boto3
 coloredlogs
 verboselogs

--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -216,19 +216,15 @@ class GeneDescriptionsETL(ETL):
                                                                 data_provider)
         descriptions = []
         best_orthologs = self.get_best_orthologs_from_db(data_provider=data_provider)
-        gene_prefix_go = gene_prefix
-        if gd_data_manager.go_associations and len(list(gd_data_manager.go_associations.associations_by_subj.keys())) > 0 and list(gd_data_manager.go_associations.associations_by_subj.keys())[0].startswith(data_provider + ":" + data_provider + ":"):
-            gene_prefix_go = data_provider + ":" + gene_prefix_go
         for record in return_set:
             gene = Gene(id=gene_prefix + record["g.primaryKey"], name=record["g.symbol"], dead=False, pseudo=False)
-            gene_go = Gene(id=gene_prefix_go + record["g.primaryKey"], name=record["g.symbol"], dead=False, pseudo=False)
             gene_desc = GeneDescription(gene_id=record["g.primaryKey"],
                                         gene_name=gene.name,
                                         add_gene_name=False,
                                         config=gd_config)
             set_gene_ontology_module(dm=gd_data_manager,
                                      conf_parser=gd_config,
-                                     gene_desc=gene_desc, gene=gene_go)
+                                     gene_desc=gene_desc, gene=gene)
             set_expression_module(df=gd_data_manager,
                                   conf_parser=gd_config,
                                   gene_desc=gene_desc,

--- a/src/test/test_object.py
+++ b/src/test/test_object.py
@@ -178,7 +178,7 @@ class TestObject():
             'ZDB-GENE-040426-1746', 'ZDB-GENE-040426-2185', 'ZDB-GENE-040426-2185',
             'ENSEMBL:ENSDART00000138978'
             # allele for synonym
-            'ZFIN:ZDB-ALT-980413-591',
+            'ZFIN:ZDB-ALT-980413-591', 'ZFIN:ZDB-ALT-161003-16981', 'ZFIN:ZDB-ALT-161003-14296',
             # disease specific test objects
             'ZFIN:ZDB-GENE-030131-5607', 'ZFIN:ZDB-GENE-050517-20',
             'ZFIN:ZDB-GENE-990415-122', 'ZFIN:ZDB-GENE-980526-41',


### PR DESCRIPTION
This PR adds a new sentence template for 'is_active_in' qualifiers, and points to a new agr_genedescriptions release that includes the code to add the related sentences to the descriptions. The new agr_genedescriptions version also fixes a bug that was previously managed by patching ontobio, and the loader can now use a standard version of ontobio instead of the patched one.