### PR TITLE
AGR-3067: fixed bugs in gaf 2.2 gene description templates

### DIFF
--- a/gene_descriptions.yml
+++ b/gene_descriptions.yml
@@ -316,11 +316,11 @@ go_sentences_options:
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is a"
+                prefix: "a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is an"
+                prefix: "an"
                 postfix: ""
         - aspect: F
           group: EXPERIMENTAL
@@ -344,11 +344,11 @@ go_sentences_options:
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is a"
+                prefix: "a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is an"
+                prefix: "an"
                 postfix: ""
         - aspect: F
           group: HIGH_THROUGHPUT_EXPERIMENTAL
@@ -367,86 +367,86 @@ go_sentences_options:
         - aspect: F
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "enables"
-          prefix: "is predicted to enable"
+          prefix: "predicted to enable"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to be a"
+                prefix: "predicted to be a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is predicted to be an"
+                prefix: "predicted to be an"
                 postfix: ""
         - aspect: F
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "contributes_to"
-          prefix: "is predicted to contribute to"
+          prefix: "predicted to contribute to"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to contribute as a"
+                prefix: "predicted to contribute as a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is an"
-                postfix: "is predicted to contribute as an"
+                prefix: "an"
+                postfix: "predicted to contribute as an"
         - aspect: F
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "enables"
-          prefix: "is predicted to enable"
+          prefix: "predicted to enable"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to be a"
+                prefix: "predicted to be a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is predicted to be an"
+                prefix: "predicted to be an"
                 postfix: ""
         - aspect: F
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "contributes_to"
-          prefix: "is predicted to contribute to"
+          prefix: "predicted to contribute to"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to contribute as a"
+                prefix: "predicted to contribute as a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is predicted to contribute as an"
+                prefix: "predicted to contribute as an"
                 postfix: ""
         - aspect: F
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "enables"
-          prefix: "is predicted to enable"
+          prefix: "predicted to enable"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to be a"
+                prefix: "predicted to be a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is predicted to be an"
+                prefix: "predicted to be an"
                 postfix: ""
         - aspect: F
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "contributes_to"
-          prefix: "is predicted to contribute to"
+          prefix: "predicted to contribute to"
           postfix: ""
           special_cases:
               - id: 1
                 match_regex: "structural constituent"
-                prefix: "is predicted to contribute as a"
+                prefix: "predicted to contribute as a"
                 postfix: ""
               - id: 2
                 match_regex: "^extracellular matrix structural constituent"
-                prefix: "is predicted to contribute as an"
+                prefix: "predicted to contribute as an"
                 postfix: ""
 
         - aspect: P

--- a/gene_descriptions.yml
+++ b/gene_descriptions.yml
@@ -526,19 +526,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "involved_in"
-          prefix: "involved in"
+          prefix: "predicted to be involved in"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "involved_in"
-          prefix: "involved in"
+          prefix: "predicted to be involved in"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "involved_in"
-          prefix: "involved in"
+          prefix: "predicted to be involved in"
           postfix: ""
           special_cases:
         - aspect: P
@@ -556,19 +556,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "acts_upstream_of_positive_effect"
-          prefix: "acts upstream of with a positive effect on"
+          prefix: "predicted to act upstream of with a positive effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "acts_upstream_of_positive_effect"
-          prefix: "acts upstream of with a positive effect on"
+          prefix: "predicted to act upstream of with a positive effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "acts_upstream_of_positive_effect"
-          prefix: "acts upstream of with a positive effect on"
+          prefix: "predicted to act upstream of with a positive effect on"
           postfix: ""
           special_cases:
         - aspect: P
@@ -586,19 +586,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "acts_upstream_of_negative_effect"
-          prefix: "acts upstream of with a negative effect on"
+          prefix: "predicted to act upstream of with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "acts_upstream_of_negative_effect"
-          prefix: "acts upstream of with a negative effect on"
+          prefix: "predicted to act upstream of with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "acts_upstream_of_negative_effect"
-          prefix: "acts upstream of with a negative effect on"
+          prefix: "predicted to act upstream of with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
@@ -616,19 +616,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "acts_upstream_of_or_within"
-          prefix: "acts upstream of or within"
+          prefix: "predicted to act upstream of or within"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "acts_upstream_of_or_within"
-          prefix: "acts upstream of or within"
+          prefix: "predicted to act upstream of or within"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "acts_upstream_of_or_within"
-          prefix: "acts upstream of or within"
+          prefix: "predicted to act upstream of or within"
           postfix: ""
           special_cases:
         - aspect: P
@@ -646,19 +646,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "acts_upstream_of_or_within_negative_effect"
-          prefix: "acts upstream of or within with a negative effect on"
+          prefix: "predicted to act upstream of or within with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "acts_upstream_of_or_within_negative_effect"
-          prefix: "acts upstream of or within with a negative effect on"
+          prefix: "predicted to act upstream of or within with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "acts_upstream_of_or_within_negative_effect"
-          prefix: "acts upstream of or within with a negative effect on"
+          prefix: "predicted to act upstream of or within with a negative effect on"
           postfix: ""
           special_cases:
         - aspect: P
@@ -676,19 +676,19 @@ go_sentences_options:
         - aspect: P
           group: PHYLOGENETIC_ANALYSIS_AND_SEQUENCE_BASED_ANALYSIS
           qualifier: "acts_upstream_of_or_within_positive_effect"
-          prefix: "acts upstream of or within with a positive effect on"
+          prefix: "predicted to act upstream of or within with a positive effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: INFERRED_BY_CURATORS_AND_AUTHORS
           qualifier: "acts_upstream_of_or_within_positive_effect"
-          prefix: "acts upstream of or within with a positive effect on"
+          prefix: "predicted to act upstream of or within with a positive effect on"
           postfix: ""
           special_cases:
         - aspect: P
           group: ELECTRONIC_AND_COMPUTATIONAL_ANALYSIS
           qualifier: "acts_upstream_of_or_within_positive_effect"
-          prefix: "acts upstream of or within with a positive effect on"
+          prefix: "predicted to act upstream of or within with a positive effect on"
           postfix: ""
           special_cases:
 


### PR DESCRIPTION
Fixed templates for gene descriptions: added predictions for GO BP and removed extra verb