### PR TITLE
Add test for SOTerm names used in transcript loader

### DIFF
--- a/src/test/specific_tests.py
+++ b/src/test/specific_tests.py
@@ -1689,3 +1689,17 @@ def test_correct_model_experimental_condition_parsing():
     for record in result:
         assert record["ec_count"] == 2
         assert record["pubj_count"] == 1
+
+def test_gff_so_terms_exist():
+    """Test that feature types in transcript loader match loaded SO names"""
+    query = """
+            MATCH (s:SOTerm) where s.name in ['gene', 'exon',
+              'CDS', 'mRNA', 'ncRNA', 'piRNA', 'lincRNA', 'miRNA',
+              'pre_miRNA', 'snoRNA', 'lncRNA', 'tRNA', 'snRNA', 'rRNA',
+              'antisense_RNA', 'C_gene_segment', 'V_gene_segment',
+              'pseudogene_attribute', 'snoRNA_gene', 'pseudogenic_transcript']
+            RETURN count(s) as counter """
+    result = execute_transaction(query)
+    for record in result:
+        assert record["counter"] == 20
+


### PR DESCRIPTION
The entries in the possible_feature list in the transcript loader
need to match the names of the loaded SO objects, otherwise those
features do not get loaded.

