### PR TITLE
SCRUM-1001: Added experimental condition conditionId property storage

### DIFF
--- a/src/etl/helpers/experimental_condition_helper.py
+++ b/src/etl/helpers/experimental_condition_helper.py
@@ -22,6 +22,7 @@ class ExperimentalConditionHelper():
 
             MERGE (ec:ExperimentalCondition {primaryKey:row.ecUniqueKey})
                 ON CREATE SET ec.conditionClassId     = row.conditionClassId,
+                            ec.conditionId          = row.conditionId,
                             ec.anatomicalOntologyId = row.anatomicalOntologyId,
                             ec.chemicalOntologyId   = row.chemicalOntologyId,
                             ec.geneOntologyId       = row.geneOntologyId,
@@ -59,7 +60,7 @@ class ExperimentalConditionHelper():
         for relation in entity_record['conditionRelations']:
             for condition in relation['conditions']:
                 # Store unique conditions
-                # Unique condition key: conditionStatement + conditionClassId
+                # Unique condition key: conditionStatement + conditionClassId + conditionId
                 #     + (anatomicalOntologyId | chemicalOntologyId | geneOntologyId | NCBITaxonID)
                 unique_key = str( condition.get('conditionStatement') or '' ) \
                               + condition.get('conditionClassId') \
@@ -73,6 +74,7 @@ class ExperimentalConditionHelper():
                     condition_dataset = {
                         "ecUniqueKey": unique_key,
                         "conditionClassId":     condition.get('conditionClassId'),
+                        "conditionId":          condition.get('conditionId'),
                         'anatomicalOntologyId': condition.get('anatomicalOntologyId'),
                         'chemicalOntologyId':   condition.get('chemicalOntologyId'),
                         'geneOntologyId':       condition.get('geneOntologyId'),

--- a/src/test/schema_node_tests.py
+++ b/src/test/schema_node_tests.py
@@ -167,6 +167,7 @@ class TestClass():
                             dict(node='DiseaseEntityJoin', prop='sortOrder'),
                             dict(node='ExperimentalCondition', prop='primaryKey'),
                             dict(node='ExperimentalCondition', prop='conditionClassId'),
+                            dict(node='ExperimentalCondition', prop='conditionId'),
                             dict(node='ExperimentalCondition', prop='anatomicalOntologyId'),
                             dict(node='ExperimentalCondition', prop='chemicalOntologyId'),
                             dict(node='ExperimentalCondition', prop='geneOntologyId'),


### PR DESCRIPTION
Added the storage of the `conditionId` property as a `:ExperimentalCondition` node property. This was incorrectly missed in the initial implementation, while it was (correctly) used as part of the (concatenated) `primaryKey`.

While this is not the cause of SCRUM-1001, it is related to the same `conditionId` property.