### PR TITLE
Bumped genedescriptions from 3.2.4 to 3.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jsonschema
 PyYAML>=5.1
 urllib3==1.26.5
 xmltodict
-git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.4#egg=genedescriptions
+git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.5#egg=genedescriptions
 git+https://github.com/alliance-genome/agr_file_generator.git@8b47011a14d9e79d13cf9239fe0cf63c54bc9b87
 ontobio==1.20.0
 boto3


### PR DESCRIPTION
The current loaderBuild and loaderPR pipelines are failing on `genedescriptions.ontology_tools`. As there is a new version of the genedescriptions tool available (as of last Friday), I hope using this new version will solve the currently observed errors.