### PR TITLE
Loader test fixes (maybe)

### DIFF
--- a/src/etl/genetic_interaction_etl.py
+++ b/src/etl/genetic_interaction_etl.py
@@ -45,10 +45,11 @@ class GeneticInteractionETL(ETL):
         CREATE (g1)-[iw:INTERACTS_WITH {uuid:row.uuid}]->(g2)
 
         //Create the Association node to be used for the object.
-        CREATE (oa:Association {primaryKey:row.uuid})
-            SET oa :InteractionGeneJoin
-            SET oa :InteractionGeneticGeneJoin
-            SET oa.joinType = 'genetic_interaction'
+        MERGE (oa:Association {primaryKey:row.uuid})
+            ON CREATE
+                SET oa :InteractionGeneJoin
+                SET oa :InteractionGeneticGeneJoin
+                SET oa.joinType = 'genetic_interaction'
         CREATE (g1)-[a1:ASSOCIATION]->(oa)
         CREATE (oa)-[a2:ASSOCIATION]->(g2)
 

--- a/src/etl/molecular_interaction_etl.py
+++ b/src/etl/molecular_interaction_etl.py
@@ -43,10 +43,11 @@ class MolecularInteractionETL(ETL):
         CREATE (g1)-[iw:INTERACTS_WITH {uuid:row.uuid}]->(g2)
 
         //Create the Association node to be used for the object.
-        CREATE (oa:Association {primaryKey:row.uuid})
-            SET oa :InteractionGeneJoin
-            SET oa :InteractionMolecularGeneJoin
-            SET oa.joinType = 'molecular_interaction'
+        MERGE (oa:Association {primaryKey:row.uuid})
+            ON CREATE
+                SET oa :InteractionGeneJoin
+                SET oa :InteractionMolecularGeneJoin
+                SET oa.joinType = 'molecular_interaction'
         CREATE (g1)-[a1:ASSOCIATION]->(oa)
         CREATE (oa)-[a2:ASSOCIATION]->(g2)
 

--- a/src/test/specific_tests.py
+++ b/src/test/specific_tests.py
@@ -366,7 +366,7 @@ def test_expression_for_non_human_species_exists():
              RETURN count(distinct s) AS counter"""
     result = execute_transaction(query)
     for record in result:
-        assert record["counter"] == 7
+        assert record["counter"] == 8
 
 
 def test_cellular_component_relationship_for_expression_exists():
@@ -1702,4 +1702,3 @@ def test_gff_so_terms_exist():
     result = execute_transaction(query)
     for record in result:
         assert record["counter"] == 20
-

--- a/src/test/test_object.py
+++ b/src/test/test_object.py
@@ -364,7 +364,10 @@ class TestObject():
             'Xenbase:XB-GENE-492505', 'Xenbase:XB-GENE-17346370', 'Xenbase:XB-GENE-1000007',
             # orthology
             'Xenbase:XB-GENE-994391', 'Xenbase:XB-GENE-1018909', 'Xenbase:XB-GENE-940436',
-            'Xenbase:XB-GENE-479538', 'Xenbase:XB-GENE-5995297', 'Xenbase:XB-GENE-5863531'
+            'Xenbase:XB-GENE-479538', 'Xenbase:XB-GENE-5995297', 'Xenbase:XB-GENE-5863531',
+            # expression
+            'Xenbase:XB-GENE-478084', 'Xenbase:XB-GENE-478165', 'Xenbase:XB-GENE-478265',
+            'Xenbase:XB-GENE-865139', 'Xenbase:XB-GENE-6254396', 'Xenbase:XB-GENE-865143'
         }
 
         self.mod_map = {"RGD": self.rgd_test_set,


### PR DESCRIPTION
@christabone @oblodgett - I've not been able to replicate the duplicate Association node primaryKey error on my local system, although I was only loading XB and RGD data.  
The only places that I've found an Association node primaryKey to be created without being in a MERGE query is in the interaction ETLs, so I've switched those CREATE queries out for MERGE ones here.  
They should have been unique even if there was duplicate data as the primaryKey is just a randomly generated UUID, but perhaps we are seeing the same issue as with the duplicate GenomicLocations?  Worth a shot?