### PR TITLE
fix(disease_via_ortho): using undirected relationship to read ortho data for disease via ortho

### DIFF
--- a/src/etl/gene_disease_ortho_etl.py
+++ b/src/etl/gene_disease_ortho_etl.py
@@ -117,7 +117,7 @@ class GeneDiseaseOrthoETL(ETL):
         self.logger.info("reached gene disease ortho retrieval")
 
         retrieve_gene_disease_ortho_query = """
-            MATCH (disease:DOTerm)-[da:IS_IMPLICATED_IN|IS_MARKER_FOR]-(gene1:Gene)-[o:ORTHOLOGOUS]->(gene2:Gene)
+            MATCH (disease:DOTerm)-[da:IS_IMPLICATED_IN|IS_MARKER_FOR]-(gene1:Gene)-[o:ORTHOLOGOUS]-(gene2:Gene)
             MATCH (ec:ECOTerm)-[ecpej:ASSOCIATION]-(pej:PublicationJoin:Association)-[:EVIDENCE]-(dej:DiseaseEntityJoin)-[a:ASSOCIATION]-(gene1:Gene)
                     WHERE o.strictFilter = true
                     AND da.uuid = dej.primaryKey


### PR DESCRIPTION
- directed relationships were used (possibly?) to speed up the disease via ortho query
- using undirected [ORTHOLOGOUS] relationships between genes returns exactly the same results for "old" MODs and adds unidirectional data from XBXL and XBXT orthology that was missing when using directed relationships

