### PR TITLE
Fix species name and taxon id in descriptions download files header (tsv and txt)

### DIFF
--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -39,15 +39,15 @@ SPECIES_BY_PROVIDER = {
     'XBXT': 'Xenopus tropicalis'
 }
 TAXON_BY_PROVIDER = {
-    'WB': 'NCBITaxon:6239',
-    'ZFIN': 'NCBITaxon:7955',
-    'FB': 'NCBITaxon:7227',
-    'HUMAN': 'NCBITaxon:9606',
-    'MGI': 'NCBITaxon:10090',
-    'RGD': 'NCBITaxon:10116',
-    'SGD': 'NCBITaxon:559292',
-    'XBXL': 'NCBITaxon:8355',
-    'XBXT': 'NCBITaxon:8364'
+    'WB': '6239',
+    'ZFIN': '7955',
+    'FB': '7227',
+    'HUMAN': '9606',
+    'MGI': '10090',
+    'RGD': '10116',
+    'SGD': '559292',
+    'XBXL': '8355',
+    'XBXT': '8364'
 }
 
 
@@ -567,7 +567,7 @@ class GeneDescriptionsETL(ETL):
         self.add_header_to_file(file_path=file_path + ".txt", header=header)
         json_desc_writer.write_tsv(file_path=file_path + ".tsv")
         header = create_header(file_type='Gene Descriptions', database_version=context_info.env["ALLIANCE_RELEASE"],
-                               data_format='tsv', readme=readme, species=species, taxon_ids='# TaxonIDs:NCBITaxon:' +
+                               data_format='tsv', readme=readme, species=species, taxon_ids='# TaxonIDs: NCBITaxon:' +
                                                                                             taxon_id)
         header = "\n".join([line.strip() for line in header.splitlines() if len(line.strip()) != 0])
         self.add_header_to_file(file_path=file_path + ".tsv", header=header)

--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -561,7 +561,7 @@ class GeneDescriptionsETL(ETL):
         taxon_id = TAXON_BY_PROVIDER[data_provider]
         species = SPECIES_BY_PROVIDER[data_provider]
         header = create_header(file_type='Gene Descriptions', database_version=context_info.env["ALLIANCE_RELEASE"],
-                               data_format='txt', readme=readme, species=species, taxon_ids='# TaxonIDs:NCBITaxon:' +
+                               data_format='txt', readme=readme, species=species, taxon_ids='# TaxonIDs: NCBITaxon:' +
                                                                                             taxon_id)
         header = "\n".join([line.strip() for line in header.splitlines() if len(line.strip()) != 0])
         self.add_header_to_file(file_path=file_path + ".txt", header=header)

--- a/src/etl/gene_descriptions_etl.py
+++ b/src/etl/gene_descriptions_etl.py
@@ -27,6 +27,28 @@ from generators.header import create_header
 
 EXPRESSION_PRVD_SUBTYPE_MAP = {'WB': 'WBBT', 'ZFIN': 'ZFA', 'FB': 'FBBT', 'MGI': 'EMAPA', 'XBXL': 'XAO', 'XBXT': 'XAO'}
 GAF_PRVD_SUBTYPE_MAP = {'XBXL': 'XB', 'XBXT': 'XB'}
+SPECIES_BY_PROVIDER = {
+    'WB': 'Caenorhabditis elegans',
+    'ZFIN': 'Danio rerio',
+    'FB': 'Drosophila melanogaster',
+    'HUMAN': 'Homo sapiens',
+    'MGI': 'Mus musculus',
+    'RGD': 'Rattus norvegicus',
+    'SGD': 'Saccharomyces cerevisiae',
+    'XBXL': 'Xenopus laevis',
+    'XBXT': 'Xenopus tropicalis'
+}
+TAXON_BY_PROVIDER = {
+    'WB': 'NCBITaxon:6239',
+    'ZFIN': 'NCBITaxon:7955',
+    'FB': 'NCBITaxon:7227',
+    'HUMAN': 'NCBITaxon:9606',
+    'MGI': 'NCBITaxon:10090',
+    'RGD': 'NCBITaxon:10116',
+    'SGD': 'NCBITaxon:559292',
+    'XBXL': 'NCBITaxon:8355',
+    'XBXT': 'NCBITaxon:8364'
+}
 
 
 logger = logging.getLogger(__name__)
@@ -536,12 +558,8 @@ class GeneDescriptionsETL(ETL):
                  "have been trimmed to an ancestor term in the ontology, in order to balance readability with the " \
                  "amount of information in the description. The complete set of annotations to any gene in this file " \
                  "may be found in the relevant data tables on the Alliance gene page."
-        # TODO Unfortunately we can no longer lookup species by data provider as Xenbase now provides multiple species.
-        # TODO The function below will need to be modified in order to lookup species and/or taxon id.
-        # species = self.etlh.species_lookup_by_data_provider(data_provider)
-        # taxon_id = self.etlh.get_taxon_from_mod(data_provider)
-        taxon_id = '1234'
-        species = 'Tempus species'
+        taxon_id = TAXON_BY_PROVIDER[data_provider]
+        species = SPECIES_BY_PROVIDER[data_provider]
         header = create_header(file_type='Gene Descriptions', database_version=context_info.env["ALLIANCE_RELEASE"],
                                data_format='txt', readme=readme, species=species, taxon_ids='# TaxonIDs:NCBITaxon:' +
                                                                                             taxon_id)


### PR DESCRIPTION
The gene descriptions etl was using helper functions to retrieve species names and taxon ids to include these fields in the download file headers. These functions were removed from the helper because they were causing issues with XB double species. and the gene desc file headers contained a default species name and taxon id.

This PR adds static maps from provider to species and taxon id in the gene descriptions etl and uses the maps to place the correct values in the headers.