### PR TITLE
Update specific_tests.py for MGI expression

### DIFF
--- a/src/test/specific_tests.py
+++ b/src/test/specific_tests.py
@@ -932,7 +932,7 @@ def test_expression_for_mgi_109583():
     RETURN count(distinct ebge) AS counter"""
     with Neo4jHelper.run_single_query(query) as result:
         for record in result:
-            assert record["counter"] == 2
+            assert record["counter"] == 5
 
 
 def test_part_of_relations_exist():


### PR DESCRIPTION
Reviewing the DQM JSON between the previous and current uploads showed 3 more entries added for this MGI gene <-> spinal cord expression association. 

The test is still working, but the expected number needs to be incremented from 2 to 5.

