### PR TITLE
fix(requirements): using a patched version of ontobio that reads IBA annotations with new GO_REF evidence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ jsonschema
 PyYAML>=5.1
 urllib3==1.26.17
 xmltodict
-git+https://github.com/alliance-genome/agr_genedescriptions.git@v3.2.5#egg=genedescriptions
+git+https://github.com/alliance-genome/agr_genedescriptions.git@patch-qc-iba-go-ref#egg=genedescriptions
 git+https://github.com/prefixcommons/prefixcommons-py.git@v0.1.11-a
-ontobio==1.20.0
+git+https://github.com/biolink/ontobio.git@patch-qc-iba-go-ref#egg=ontobio
 boto3
 coloredlogs
 verboselogs


### PR DESCRIPTION
GO has recently switched the standard reference field value in IBA GAFs from “PMID:21873635” to “GO_REF:0000033" and updated Obtobio to apply GO rules on IBA accordingly. The loader is using an older version of ontobio that did not have this change. @dustine32 patched the ontobio version used by the loader (1.20.0) in a separate branch (https://github.com/biolink/ontobio/tree/patch-qc-iba-go-ref). This PR changes the loader requirements file to use the patched version of ontobio. I also updated the gene descriptions software to use this ontobio version and pointed to the new version in the requirements file.