### PR TITLE
Fix CHEBI ontology CSV parsing error from escaped quotes in name field

### DIFF
--- a/src/etl/generic_ontology_etl.py
+++ b/src/etl/generic_ontology_etl.py
@@ -264,9 +264,17 @@ class GenericOntologyETL(ETL):
             if ident is None or ident == '':
                 self.logger.warning("Missing oid.")
             else:
+                # Get name and normalize escaped quotes for Neo4j CSV compatibility
+                # Some ontologies (e.g., CHEBI) have backslash-escaped quotes in names
+                # like: 5-Oxoavermectin \"2b\" aglycone
+                # These must be converted to regular quotes before CSV export
+                name = line.get('name')
+                if name and "\\\"" in name:
+                    name = name.replace('\\\"', '\"')
+
                 term_dict_to_append = {
-                    'name': line.get('name'),
-                    'name_key': line.get('name'),
+                    'name': name,
+                    'name_key': name,
                     'oid': ident,
                     'definition': definition,
                     'is_obsolete': is_obsolete,


### PR DESCRIPTION
## Summary

- Fixes Neo4j LOAD CSV parsing error caused by backslash-escaped quotes in CHEBI ontology term names
- The CHEBI 8.3.0 release includes terms like `5-Oxoavermectin \"2b\" aglycone` which use valid OBO format escape sequences
- These escaped quotes were causing Neo4j to fail with: *"there's a field starting with a quote and whereas it ends that quote there seems to be characters in that field after that ending quote"*

## Root Cause

The OBO format specification allows backslash-escaped quotes (`\"`) in term names. When written to CSV and imported by Neo4j:

1. Python's csv module writes: `"5-Oxoavermectin \""2b\"" aglycone"`
2. Neo4j interprets `\"` as an escape sequence, causing field boundary confusion
3. This results in a parse error at the problematic term

## Fix

Normalize escaped quotes to regular quotes in the `name` field before CSV export, consistent with the existing handling of the `definition` field (line 253-255).

## Test plan

- [ ] Verify CHEBI ontology loads successfully with the fix
- [ ] Confirm other ontologies with escaped quotes in names also work
- [ ] Check that the CSV output is valid RFC 4180 format