### PR TITLE
Add configurable sequential loading for ETL data types

### DIFF
--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -11,3 +11,10 @@ TEST_SET: False
 API_KEY: ""
 FILE_TRANSACTOR_THREADS: 10
 NEO4J_TRANSACTOR_THREADS: 8
+# Sequential ETL Types - comma-separated list of ETL type names
+# ETLs listed here will load sub-types sequentially instead of in parallel
+# This prevents Neo4j deadlocks when multiple MODs update shared nodes (e.g., Gene)
+# Valid values: PHENOTYPE, DAF, ORTHO, GAF (matches etl_dispatch keys)
+# Default: empty string (all ETLs run in parallel)
+# Example: "PHENOTYPE,DAF,GAF"
+SEQUENTIAL_ETL_TYPES: ""

--- a/src/default_env_vars.yml
+++ b/src/default_env_vars.yml
@@ -15,6 +15,5 @@ NEO4J_TRANSACTOR_THREADS: 8
 # ETLs listed here will load sub-types sequentially instead of in parallel
 # This prevents Neo4j deadlocks when multiple MODs update shared nodes (e.g., Gene)
 # Valid values: PHENOTYPE, DAF, ORTHO, GAF (matches etl_dispatch keys)
-# Default: empty string (all ETLs run in parallel)
-# Example: "PHENOTYPE,DAF,GAF"
-SEQUENTIAL_ETL_TYPES: ""
+# PHENOTYPE is enabled by default to prevent known deadlock issues
+SEQUENTIAL_ETL_TYPES: "PHENOTYPE"

--- a/src/etl/disease_etl.py
+++ b/src/etl/disease_etl.py
@@ -3,8 +3,8 @@
 # TODO need to fix the difference between disaeseRecord and disease_record in original code
 
 import logging
-import multiprocessing
 import uuid
+
 from etl import ETL
 from etl.helpers import ETLHelper
 from etl.helpers import Neo4jHelper
@@ -224,16 +224,12 @@ class DiseaseETL(ETL):
         self.exp_cond_helper = ExperimentalConditionHelper("DiseaseEntityJoin")
 
     def _load_and_process_data(self):
-        thread_pool = []
-
-        for sub_type in self.data_type_config.get_sub_type_objects():
-            process = multiprocessing.Process(target=self._process_sub_type, args=(sub_type,))
-            process.start()
-            thread_pool.append(process)
-
-        ETL.wait_for_threads(thread_pool)
-
-        self.delete_empty_nodes()
+        self.process_sub_types_with_threading(
+            self.data_type_config.get_sub_type_objects(),
+            self._process_sub_type,
+            'DAF',
+            cleanup_func=self.delete_empty_nodes
+        )
 
     def delete_empty_nodes(self):
         """Delete Empty Nodes."""

--- a/src/etl/etl.py
+++ b/src/etl/etl.py
@@ -1,6 +1,7 @@
 """ETL."""
 
 import logging
+import multiprocessing
 import sys
 import time
 
@@ -81,6 +82,96 @@ class ETL:
                     return
 
             time.sleep(5)
+
+    def process_sub_types_with_threading(self, sub_type_objects, process_func,
+                                         etl_type_name, cleanup_func=None):
+        """
+        Process sub-types either sequentially or in parallel based on configuration.
+
+        This method abstracts the decision to run ETL sub-types sequentially or in parallel,
+        based on whether the ETL type name appears in the SEQUENTIAL_ETL_TYPES environment
+        variable / config setting.
+
+        Sequential mode is useful for:
+        - Preventing Neo4j deadlocks when multiple MODs update shared nodes (e.g., Gene)
+        - Debugging and troubleshooting data loading issues
+        - Reducing memory pressure on resource-constrained systems
+
+        Args:
+            sub_type_objects: List of sub-type config objects from
+                             data_type_config.get_sub_type_objects()
+            process_func: Function to call for each sub-type. Will be called as
+                         process_func(sub_type) for each sub_type in sub_type_objects.
+                         In parallel mode, this becomes the target for multiprocessing.Process.
+            etl_type_name: The ETL type name to check against SEQUENTIAL_ETL_TYPES config.
+                          Should match the key in aggregate_loader.py's etl_dispatch
+                          (e.g., 'PHENOTYPE', 'DAF', 'ORTHO', 'GAF').
+            cleanup_func: Optional function to call after processing. In sequential mode,
+                         this is called after EACH sub-type. In parallel mode, this is
+                         called ONCE after all sub-types complete. This is important for
+                         DiseaseETL which needs to run delete_empty_nodes() after each
+                         sub-type in sequential mode for correct data cleanup.
+
+        Returns:
+            None
+
+        Configuration:
+            Set SEQUENTIAL_ETL_TYPES environment variable or config to a comma-separated
+            list of ETL type names:
+
+            # Run phenotype and disease ETLs sequentially:
+            export SEQUENTIAL_ETL_TYPES="PHENOTYPE,DAF"
+
+            # Run all listed ETLs sequentially:
+            export SEQUENTIAL_ETL_TYPES="PHENOTYPE,DAF,ORTHO,GAF"
+        """
+        context_info = ContextInfo()
+        sequential_types_str = context_info.env.get("SEQUENTIAL_ETL_TYPES", "")
+
+        # Parse comma-separated string into list, normalize to uppercase
+        if sequential_types_str and sequential_types_str.strip():
+            sequential_types = [t.strip().upper() for t in sequential_types_str.split(',') if t.strip()]
+        else:
+            sequential_types = []
+
+        # Check if this ETL should run sequentially
+        run_sequentially = etl_type_name.upper() in sequential_types
+
+        if run_sequentially:
+            self.logger.info("Loading %s sub-types SEQUENTIALLY (configured for deadlock prevention)",
+                             etl_type_name)
+
+            # Sequential execution: process each sub-type one at a time
+            for sub_type in sub_type_objects:
+                self.logger.info("Processing sub-type sequentially: %s", sub_type.get_data_provider())
+                process_func(sub_type)
+
+                # Run cleanup after EACH sub-type in sequential mode
+                if cleanup_func is not None:
+                    self.logger.debug("Running cleanup after sub-type: %s", sub_type.get_data_provider())
+                    cleanup_func()
+
+            self.logger.info("Completed %s sequential loading (%d sub-types)",
+                             etl_type_name, len(sub_type_objects))
+        else:
+            self.logger.info("Loading %s sub-types in PARALLEL (%d sub-types)",
+                             etl_type_name, len(sub_type_objects))
+
+            # Parallel execution: spawn process for each sub-type
+            thread_pool = []
+            for sub_type in sub_type_objects:
+                process = multiprocessing.Process(target=process_func, args=(sub_type,))
+                process.start()
+                thread_pool.append(process)
+
+            ETL.wait_for_threads(thread_pool)
+
+            # Run cleanup ONCE after all parallel processes complete
+            if cleanup_func is not None:
+                self.logger.debug("Running cleanup after parallel processing")
+                cleanup_func()
+
+            self.logger.info("Completed %s parallel loading", etl_type_name)
 
     def process_query_params(self, query_list_with_params):
         """Process Query Params."""

--- a/src/etl/go_annot_etl.py
+++ b/src/etl/go_annot_etl.py
@@ -33,16 +33,17 @@ class GOAnnotETL(ETL):
         self.data_type_config = config
 
     def _load_and_process_data(self):
-        thread_pool = []
-
         query_tracking_list = multiprocessing.Manager().list()
-        for sub_type in self.data_type_config.get_sub_type_objects():
-            process = multiprocessing.Process(target=self._process_sub_type,
-                                              args=(sub_type, query_tracking_list))
-            process.start()
-            thread_pool.append(process)
 
-        ETL.wait_for_threads(thread_pool)
+        # Wrapper function to pass query_tracking_list to _process_sub_type
+        def process_wrapper(sub_type):
+            self._process_sub_type(sub_type, query_tracking_list)
+
+        self.process_sub_types_with_threading(
+            self.data_type_config.get_sub_type_objects(),
+            process_wrapper,
+            'GAF'
+        )
 
         queries = []
         for item in query_tracking_list:

--- a/src/etl/orthology_etl.py
+++ b/src/etl/orthology_etl.py
@@ -117,17 +117,17 @@ class OrthologyETL(ETL):
         for sub_type in self.data_type_config.get_sub_type_objects():
             sub_types.append(sub_type.get_data_provider())
 
-        thread_pool = []
-
         query_tracking_list = multiprocessing.Manager().list()
-        for sub_type in self.data_type_config.get_sub_type_objects():
-            process = multiprocessing.Process(target=self._process_sub_type,
-                                              args=(sub_type, sub_types,
-                                                    query_tracking_list))
-            process.start()
-            thread_pool.append(process)
 
-        ETL.wait_for_threads(thread_pool)
+        # Wrapper function to pass extra arguments to _process_sub_type
+        def process_wrapper(sub_type):
+            self._process_sub_type(sub_type, sub_types, query_tracking_list)
+
+        self.process_sub_types_with_threading(
+            self.data_type_config.get_sub_type_objects(),
+            process_wrapper,
+            'ORTHO'
+        )
 
         queries = []
         for item in query_tracking_list:

--- a/src/etl/phenotype_etl.py
+++ b/src/etl/phenotype_etl.py
@@ -2,7 +2,6 @@
 
 import logging
 import uuid
-import multiprocessing
 
 from etl import ETL
 from etl.helpers import ExperimentalConditionHelper
@@ -158,14 +157,11 @@ class PhenoTypeETL(ETL):
         self.exp_cond_helper = ExperimentalConditionHelper("PhenotypeEntityJoin")
 
     def _load_and_process_data(self):
-        thread_pool = []
-
-        for sub_type in self.data_type_config.get_sub_type_objects():
-            process = multiprocessing.Process(target=self._process_sub_type, args=(sub_type,))
-            process.start()
-            thread_pool.append(process)
-
-        ETL.wait_for_threads(thread_pool)
+        self.process_sub_types_with_threading(
+            self.data_type_config.get_sub_type_objects(),
+            self._process_sub_type,
+            'PHENOTYPE'
+        )
 
     def _process_sub_type(self, sub_type):
 

--- a/src/transactors/neo4j_transactor.py
+++ b/src/transactors/neo4j_transactor.py
@@ -38,9 +38,233 @@ class Neo4jTransactor():
         self.thread_pool = []
 
 
+    # Query result constants for _process_single_query return values
+    QUERY_SUCCESS = "success"
+    QUERY_REQUEUE = "requeue"  # Requeued for retry, continue to next batch
+    QUERY_FATAL = "fatal"  # Unrecoverable error, worker should stop
+
     @staticmethod
     def _get_name():
         return "Neo4jTransactor %s" % multiprocessing.current_process().name
+
+    def _execute_neo4j_query(self, graph, neo4j_query, filename, process_name):
+        """Execute a single Neo4j query with timeout. Returns result on success, raises on error."""
+        if not graph:
+            raise ConnectionError("Neo4j driver not initialized in worker.")
+        query_with_timeout = Query(neo4j_query, timeout=self.QUERY_TIMEOUT)
+        self.logger.debug("%s: Executing query for file %s with timeout=%ss",
+                          process_name, filename, self.QUERY_TIMEOUT)
+        with graph.session() as session:
+            result = session.run(query_with_timeout)
+            result.consume()  # CRITICAL: Ensure query is fully executed (Neo4j uses lazy evaluation)
+
+    def _recreate_neo4j_driver(self, graph, process_name):
+        """Close existing driver and create a new one. Returns the new driver."""
+        context_info = ContextInfo()
+        if graph:
+            try:
+                graph.close()
+            except Exception:
+                pass
+        uri = "bolt://" + context_info.env["NEO4J_HOST"] + ":" + str(context_info.env["NEO4J_PORT"])
+        new_graph = GraphDatabase.driver(
+            uri,
+            auth=("neo4j", "neo4j"),
+            max_connection_pool_size=self.MAX_CONNECTION_POOL_SIZE,
+            connection_timeout=self.CONNECTION_TIMEOUT,
+            connection_acquisition_timeout=self.CONNECTION_ACQUISITION_TIMEOUT,
+            max_connection_lifetime=self.MAX_CONNECTION_LIFETIME,
+        )
+        new_graph.verify_connectivity()  # Fail fast if Neo4j is truly down
+        self.logger.info(f"{process_name}: Recreated Neo4j driver after connection error")
+        return new_graph
+
+    def _handle_transient_error(self, error, batch_data, query_counter, process_name, filename,
+                                 current_index, max_retries, base_retry_sleep):
+        """
+        Handle Neo4j TransientError (deadlocks). Requeues batch for retry.
+        Returns QUERY_REQUEUE if requeued, raises RuntimeError if max retries exceeded.
+        """
+        self.logger.error(f"{process_name}: Neo4j TransientError processing file {filename} "
+                          f"at index {current_index}: {error}", exc_info=False)
+        batch_data['retries'] += 1
+        self.logger.warning(
+            "%s: Query Conflict (TransientError), putting data back in Queue to run later. "
+            "File: %s (Retry %d/%d)",
+            process_name, filename, batch_data['retries'], max_retries)
+
+        if batch_data['retries'] > max_retries:
+            self.logger.critical(
+                "%s: FATAL - Max retries (%d) exceeded for file: %s at Index %s. "
+                "Data cannot be loaded. Failing program.",
+                process_name, max_retries, filename, current_index)
+            raise RuntimeError(
+                f"Max retries ({max_retries}) exceeded for file {filename} at index {current_index}. "
+                f"TransientError (deadlock) could not be resolved. Data load failed."
+            )
+
+        # Requeue with incremental backoff
+        Neo4jTransactor.queue.put((batch_data, query_counter))
+        sleep_time = base_retry_sleep + batch_data['retries']
+        self.logger.info(f"{process_name}: Sleeping for {sleep_time} seconds before retry for batch {batch_data['batch_id']}")
+        time.sleep(sleep_time)
+        return self.QUERY_REQUEUE
+
+    def _handle_connection_error(self, error, error_type, batch_data, query_counter, graph,
+                                  process_name, filename, current_index):
+        """
+        Handle ServiceUnavailable/SessionExpired. Requeues batch and optionally recreates driver.
+        Returns (QUERY_REQUEUE, new_graph) if requeued, raises RuntimeError if max retries exceeded.
+        """
+        self.logger.error(f"{process_name}: Neo4j {error_type} for file {filename} "
+                          f"at index {current_index}: {error}", exc_info=False)
+        batch_data['timeout_retries'] += 1
+        self.logger.warning(
+            "%s: %s, will retry. File: %s (Timeout Retry %d/%d)",
+            process_name, error_type, filename, batch_data['timeout_retries'], self.MAX_TIMEOUT_RETRIES)
+
+        if batch_data['timeout_retries'] > self.MAX_TIMEOUT_RETRIES:
+            self.logger.critical(
+                "%s: FATAL - Max timeout retries (%d) exceeded for file: %s at Index %s. "
+                "%s. Failing program.",
+                process_name, self.MAX_TIMEOUT_RETRIES, filename, current_index, error_type)
+            raise RuntimeError(
+                f"Max timeout retries ({self.MAX_TIMEOUT_RETRIES}) exceeded for file {filename} "
+                f"at index {current_index}. {error_type}. Data load failed."
+            )
+
+        # Recreate driver for ServiceUnavailable
+        new_graph = graph
+        if error_type == "ServiceUnavailable":
+            new_graph = self._recreate_neo4j_driver(graph, process_name)
+            sleep_time = 30 + (batch_data['timeout_retries'] * 10)
+        else:  # SessionExpired
+            sleep_time = 20 + (batch_data['timeout_retries'] * 5)
+
+        Neo4jTransactor.queue.put((batch_data, query_counter))
+        self.logger.info(f"{process_name}: Sleeping for {sleep_time} seconds before retry after {error_type}")
+        time.sleep(sleep_time)
+        return self.QUERY_REQUEUE, new_graph
+
+    def _process_single_query(self, graph, batch_data, query_counter, process_name,
+                               max_retries, base_retry_sleep):
+        """
+        Process a single query from the batch at the current index.
+        Returns (result_code, updated_graph) where result_code is one of:
+          - QUERY_SUCCESS: Query succeeded, index incremented
+          - QUERY_REQUEUE: Batch requeued for retry, should break inner loop
+          - QUERY_FATAL: Unrecoverable error, raises exception
+        """
+        context_info = ContextInfo()
+        current_index = batch_data['next_query_index']
+        all_queries = batch_data['all_queries']
+        (neo4j_query, filename) = all_queries[current_index]
+        batch_id = batch_data['batch_id']
+
+        queue_size = -1
+        try:
+            queue_size = Neo4jTransactor.queue.qsize()
+        except NotImplementedError:
+            pass
+
+        self.logger.debug("%s: Processing query for file: %s QueryNum: %s Index: %s QueueSize: %s",
+                          process_name, filename, batch_id, current_index, queue_size)
+        start = time.time()
+
+        try:
+            if context_info.env["USING_PICKLE"] is True:
+                pickle_dir = context_info.env.get("PICKLE_PATH", "tmp/temp")
+                file_name = f"{pickle_dir}/transaction_{batch_id}_{current_index}.pkl"
+                with open(file_name, 'wb') as file:
+                    self.logger.debug("Writing to file: %s", file_name)
+                    pickle.dump(neo4j_query, file)
+            else:
+                self._execute_neo4j_query(graph, neo4j_query, filename, process_name)
+
+            # Success - log and update state
+            elapsed_time = time.time() - start
+            self.logger.info("%s: Processed query for file: %s QueryNum: %s Index: %s QueueSize: %s Time: %s",
+                             process_name, filename, batch_id, current_index, queue_size,
+                             time.strftime("%H:%M:%S", time.gmtime(elapsed_time)))
+            batch_data['next_query_index'] += 1
+            batch_data['retries'] = 0
+            batch_data['timeout_retries'] = 0
+            return self.QUERY_SUCCESS, graph
+
+        except neo4j_exceptions.ClientError as error:
+            # Non-retryable errors (constraint violations, etc.)
+            self.logger.error(f"{process_name}: Neo4j ClientError processing file {filename} "
+                              f"at index {current_index}: {error}", exc_info=True)
+            if hasattr(error, 'code') and 'ConstraintValidationFailed' in error.code:
+                self.logger.critical("%s: Constraint violation, aborting. File: %s", process_name, filename)
+            else:
+                self.logger.error("%s: Unrecoverable ClientError. File: %s", process_name, filename)
+            raise error
+
+        except neo4j_exceptions.TransientError as error:
+            result = self._handle_transient_error(
+                error, batch_data, query_counter, process_name, filename,
+                current_index, max_retries, base_retry_sleep)
+            return result, graph
+
+        except neo4j_exceptions.ServiceUnavailable as error:
+            result, new_graph = self._handle_connection_error(
+                error, "ServiceUnavailable", batch_data, query_counter, graph,
+                process_name, filename, current_index)
+            return result, new_graph
+
+        except neo4j_exceptions.SessionExpired as error:
+            result, new_graph = self._handle_connection_error(
+                error, "SessionExpired", batch_data, query_counter, graph,
+                process_name, filename, current_index)
+            return result, new_graph
+
+        except ConnectionError as error:
+            self.logger.critical(
+                "%s: FATAL - ConnectionError for file %s at index %s: %s. Failing program.",
+                process_name, filename, current_index, error)
+            raise RuntimeError(
+                f"ConnectionError for file {filename} at index {current_index}: {error}. "
+                f"Neo4j driver not available. Data load failed."
+            ) from error
+
+        except Exception as error:
+            self.logger.critical(
+                "%s: FATAL - Unexpected error for file %s at index %s: %s. Failing program.",
+                process_name, filename, current_index, error, exc_info=True)
+            raise RuntimeError(
+                f"Unexpected error for file {filename} at index {current_index}: {error}. "
+                f"Data load failed."
+            ) from error
+
+    def _process_batch(self, graph, batch_data, query_counter, process_name, max_retries, base_retry_sleep):
+        """
+        Process all queries in a batch. Returns updated graph (may be recreated on connection errors).
+        """
+        batch_id = batch_data['batch_id']
+        all_queries = batch_data['all_queries']
+        batch_start = time.time()
+        processed_this_attempt = 0
+        batch_requeued = False
+
+        while batch_data['next_query_index'] < len(all_queries):
+            result, graph = self._process_single_query(
+                graph, batch_data, query_counter, process_name, max_retries, base_retry_sleep)
+
+            if result == self.QUERY_SUCCESS:
+                processed_this_attempt += 1
+            elif result == self.QUERY_REQUEUE:
+                batch_requeued = True
+                break  # Exit inner loop, batch was requeued
+
+        batch_elapsed = time.time() - batch_start
+        self.logger.debug(
+            "%s: Query Batch attempt finished: %s ProcessedThisAttempt: %s Requeued: %s "
+            "TotalInBatch: %s Time: %s",
+            process_name, batch_id, processed_this_attempt, batch_requeued,
+            len(all_queries), time.strftime("%H:%M:%S", time.gmtime(batch_elapsed)))
+
+        return graph
 
     def start_threads(self, thread_count):
         """Start Threads"""
@@ -155,224 +379,20 @@ class Neo4jTransactor():
                         graph.close()
                     return
 
-            # --- Extract state from batch_data --- # Added comment
-            batch_id = batch_data['batch_id'] # Get batch_id from dict
-            all_queries = batch_data['all_queries'] # Get full query list from dict
-
-            # Original batch processing log - adapted slightly
+            # Log batch start
+            batch_id = batch_data['batch_id']
             self.logger.debug("%s: Processing query batch: %s StartingIndex: %s TotalQueries: %s",
-                              process_name, batch_id, batch_data['next_query_index'], len(all_queries)) # Use state vars
-            batch_start = time.time()
+                              process_name, batch_id, batch_data['next_query_index'],
+                              len(batch_data['all_queries']))
 
-            # total_query_counter = 0 # Removed original counter
-
-            processed_this_attempt = 0 # Added counter for this attempt
-            batch_requeued = False # Added flag
-
-            # --- Inner loop iterates using the index --- # Added comment
-            while batch_data['next_query_index'] < len(all_queries): # Loop based on index
-                current_index = batch_data['next_query_index'] # Get current index
-                # Get query based on index from the stored list
-                (neo4j_query, filename) = all_queries[current_index] # Access query by index
-
-                # Original query processing log - adapted for index
-                queue_size = -1
-                try: queue_size = Neo4jTransactor.queue.qsize()
-                except NotImplementedError: pass
-                self.logger.debug("%s: Processing query for file: %s QueryNum: %s Index: %s QueueSize: %s",
-                                  process_name, filename, batch_id, current_index, queue_size) # Use state vars
-                start = time.time()
-                try:
-                    # Original Pickle logic - adapted for index in filename
-                    if context_info.env["USING_PICKLE"] is True:
-                        pickle_dir = context_info.env.get("PICKLE_PATH", "tmp/temp") # Get path
-                        # Original filename formatting used index/counter, adapt slightly
-                        file_name = f"{pickle_dir}/transaction_{batch_id}_{current_index}.pkl" # Use index
-                        with open(file_name, 'wb') as file:
-                            self.logger.debug("Writing to file: %s", file_name) # Use f-string for path
-                            pickle.dump(neo4j_query, file)
-                    else:
-                        # Neo4j execution with query-level timeout
-                        if not graph:
-                            raise ConnectionError("Neo4j driver not initialized in worker.")
-                        # Wrap query with timeout to prevent indefinite hangs on long-running queries
-                        query_with_timeout = Query(neo4j_query, timeout=self.QUERY_TIMEOUT)
-                        self.logger.debug("%s: Executing query for file %s with timeout=%ss",
-                                          process_name, filename, self.QUERY_TIMEOUT)
-                        with graph.session() as session:
-                            result = session.run(query_with_timeout)
-                            result.consume()  # CRITICAL: Ensure query is fully executed (Neo4j uses lazy evaluation)
-
-                    # --- Success --- #
-                    end = time.time()
-                    elapsed_time = end - start
-                    # Original success log - adapted for index
-                    self.logger.info("%s: Processed query for file: %s QueryNum: %s Index: %s QueueSize: %s Time: %s",
-                                     process_name, filename, batch_id, current_index, queue_size,
-                                     time.strftime("%H:%M:%S", time.gmtime(elapsed_time))) # Use state vars
-                    # --- IMPORTANT: Increment index and reset retries on success --- #
-                    batch_data['next_query_index'] += 1 # Increment index
-                    batch_data['retries'] = 0 # Reset retries
-                    batch_data['timeout_retries'] = 0 # Reset timeout retries on success
-                    processed_this_attempt += 1 # Increment attempt counter
-                    # --- End Success --- # 
-
-                # Specific handling for Neo4j Client Errors (e.g., constraints) - Non-retryable
-                except neo4j_exceptions.ClientError as error:
-                    self.logger.error(f"{process_name}: Neo4j ClientError processing file {filename} at index {current_index}: {error}", exc_info=True)
-                    # Check if it's a constraint violation
-                    if hasattr(error, 'code') and 'ConstraintValidationFailed' in error.code:
-                        self.logger.critical(
-                            "%s: Constraint violation, aborting processing for file: %s. Worker stopping.",
-                            process_name, filename)
-                    else:
-                         self.logger.error(
-                            "%s: Unrecoverable ClientError processing file: %s. Worker stopping.",
-                            process_name, filename)
-                    raise error # Stop worker for all ClientErrors
-
-                # Specific handling for Neo4j Transient Errors (e.g., deadlocks) - Retryable
-                except neo4j_exceptions.TransientError as error:
-                    # Log transient errors without full traceback unless debugging needed
-                    self.logger.error(f"{process_name}: Neo4j TransientError processing file {filename} at index {current_index}: {error}", exc_info=False)
-                    batch_data['retries'] += 1
-                    self.logger.warning(
-                        "%s: Query Conflict (TransientError), putting data back in Queue to run later. File: %s (Retry %d/%d)",
-                        process_name, filename, batch_data['retries'], max_retries)
-
-                    if batch_data['retries'] > max_retries:
-                        # FAIL LOUDLY - 100% of data must be loaded
-                        self.logger.critical(
-                            "%s: FATAL - Max retries (%d) exceeded for file: %s at Index %s. "
-                            "Data cannot be loaded. Failing program.",
-                            process_name, max_retries, filename, current_index)
-                        raise RuntimeError(
-                            f"Max retries ({max_retries}) exceeded for file {filename} at index {current_index}. "
-                            f"TransientError (deadlock) could not be resolved. Data load failed."
-                        )
-                    # Else perform requeue and incremental backoff
-                    try:
-                        Neo4jTransactor.queue.put((batch_data, query_counter))
-                        batch_requeued = True
-                        # Incremental backoff for sleep time
-                        sleep_time = base_retry_sleep + batch_data['retries']
-                        self.logger.info(f"{process_name}: Sleeping for {sleep_time} seconds before retry for batch {batch_id}")
-                        time.sleep(sleep_time)
-                    except Exception as queue_err:
-                        self.logger.error(f"{process_name}: Failed to requeue Batch {batch_id} after TransientError: {queue_err}. Worker stopping.", exc_info=True)
-                        raise queue_err
-                    break  # exit inner loop to wait before next attempt
-
-                # Handle ServiceUnavailable (connection lost, timeout, etc.) - Retryable
-                except neo4j_exceptions.ServiceUnavailable as error:
-                    self.logger.error(f"{process_name}: Neo4j ServiceUnavailable for file {filename} at index {current_index}: {error}", exc_info=False)
-                    batch_data['timeout_retries'] += 1
-                    self.logger.warning(
-                        "%s: Connection/timeout error, will retry. File: %s (Timeout Retry %d/%d)",
-                        process_name, filename, batch_data['timeout_retries'], self.MAX_TIMEOUT_RETRIES)
-
-                    if batch_data['timeout_retries'] > self.MAX_TIMEOUT_RETRIES:
-                        # FAIL LOUDLY - 100% of data must be loaded
-                        self.logger.critical(
-                            "%s: FATAL - Max timeout retries (%d) exceeded for file: %s at Index %s. "
-                            "Neo4j connection unavailable. Failing program.",
-                            process_name, self.MAX_TIMEOUT_RETRIES, filename, current_index)
-                        raise RuntimeError(
-                            f"Max timeout retries ({self.MAX_TIMEOUT_RETRIES}) exceeded for file {filename} at index {current_index}. "
-                            f"ServiceUnavailable - Neo4j connection could not be established. Data load failed."
-                        )
-                    # Requeue with longer backoff for connection issues
-                    try:
-                        # Recreate driver in case connection is completely broken
-                        if graph:
-                            try:
-                                graph.close()
-                            except Exception:
-                                pass
-                        uri = "bolt://" + context_info.env["NEO4J_HOST"] + ":" + str(context_info.env["NEO4J_PORT"])
-                        graph = GraphDatabase.driver(
-                            uri,
-                            auth=("neo4j", "neo4j"),
-                            max_connection_pool_size=self.MAX_CONNECTION_POOL_SIZE,
-                            connection_timeout=self.CONNECTION_TIMEOUT,
-                            connection_acquisition_timeout=self.CONNECTION_ACQUISITION_TIMEOUT,
-                            max_connection_lifetime=self.MAX_CONNECTION_LIFETIME,
-                        )
-                        graph.verify_connectivity()  # Fail fast if Neo4j is truly down
-                        self.logger.info(f"{process_name}: Recreated Neo4j driver after connection error")
-
-                        Neo4jTransactor.queue.put((batch_data, query_counter))
-                        batch_requeued = True
-                        # Longer backoff for connection issues (30 seconds base + retries * 10)
-                        sleep_time = 30 + (batch_data['timeout_retries'] * 10)
-                        self.logger.info(f"{process_name}: Sleeping for {sleep_time} seconds before retry after connection error")
-                        time.sleep(sleep_time)
-                    except Exception as queue_err:
-                        self.logger.critical(f"{process_name}: CRITICAL - Failed to requeue after ServiceUnavailable: {queue_err}. DATA MAY BE LOST!", exc_info=True)
-                        raise queue_err
-                    break
-
-                # Handle SessionExpired (session timeout) - Retryable
-                except neo4j_exceptions.SessionExpired as error:
-                    self.logger.error(f"{process_name}: Neo4j SessionExpired for file {filename} at index {current_index}: {error}", exc_info=False)
-                    batch_data['timeout_retries'] += 1
-                    self.logger.warning(
-                        "%s: Session expired, will retry. File: %s (Timeout Retry %d/%d)",
-                        process_name, filename, batch_data['timeout_retries'], self.MAX_TIMEOUT_RETRIES)
-
-                    if batch_data['timeout_retries'] > self.MAX_TIMEOUT_RETRIES:
-                        # FAIL LOUDLY - 100% of data must be loaded
-                        self.logger.critical(
-                            "%s: FATAL - Max timeout retries (%d) exceeded for file: %s at Index %s. "
-                            "Session expired repeatedly. Failing program.",
-                            process_name, self.MAX_TIMEOUT_RETRIES, filename, current_index)
-                        raise RuntimeError(
-                            f"Max timeout retries ({self.MAX_TIMEOUT_RETRIES}) exceeded for file {filename} at index {current_index}. "
-                            f"SessionExpired - Neo4j session could not be maintained. Data load failed."
-                        )
-                    # Requeue with backoff
-                    try:
-                        Neo4jTransactor.queue.put((batch_data, query_counter))
-                        batch_requeued = True
-                        sleep_time = 20 + (batch_data['timeout_retries'] * 5)
-                        self.logger.info(f"{process_name}: Sleeping for {sleep_time} seconds before retry after session expiry")
-                        time.sleep(sleep_time)
-                    except Exception as queue_err:
-                        self.logger.critical(f"{process_name}: CRITICAL - Failed to requeue after SessionExpired: {queue_err}. DATA MAY BE LOST!", exc_info=True)
-                        raise queue_err
-                    break
-
-                # Handle potential connection issues explicitly (driver not initialized)
-                except ConnectionError as error:
-                    self.logger.critical(
-                        "%s: FATAL - ConnectionError for file %s at index %s: %s. "
-                        "Neo4j driver not available. Failing program.",
-                        process_name, filename, current_index, error)
-                    raise RuntimeError(
-                        f"ConnectionError for file {filename} at index {current_index}: {error}. "
-                        f"Neo4j driver not available. Data load failed."
-                    ) from error
-
-                # Catch-all for other unexpected errors
-                except Exception as error:
-                    self.logger.critical(
-                        "%s: FATAL - Unexpected error for file %s at index %s: %s. Failing program.",
-                        process_name, filename, current_index, error, exc_info=True)
-                    raise RuntimeError(
-                        f"Unexpected error for file {filename} at index {current_index}: {error}. "
-                        f"Data load failed."
-                    ) from error
-
-            # --- End of inner while loop --- 
-
-            batch_end = time.time()
-            batch_elapsed_time = batch_end - batch_start
-            # Original batch finished log - adapted slightly for new state info
-            # Using original len(query_batch) might be confusing now, using len(all_queries) from state
-            self.logger.debug("%s: Query Batch attempt finished: %s ProcessedThisAttempt: %s Requeued: %s TotalInBatch: %s Time: %s",
-                              process_name, batch_id, processed_this_attempt, batch_requeued,
-                              len(all_queries), # Use length from state dict
-                              time.strftime("%H:%M:%S", time.gmtime(batch_elapsed_time)))
-            # ALWAYS call task_done() - each get() from queue needs a corresponding task_done()
-            # Requeued items are NEW tasks that will get their own task_done() when processed
-            Neo4jTransactor.queue.task_done()
+            # CRITICAL: Wrap batch processing in try/finally to ensure task_done() is ALWAYS called.
+            # Without this, if a worker crashes (RuntimeError from max retries exceeded), task_done()
+            # is never called, causing queue.join() to hang forever waiting for a task that will never complete.
+            try:
+                graph = self._process_batch(
+                    graph, batch_data, query_counter, process_name, max_retries, base_retry_sleep)
+            finally:
+                # CRITICAL: ALWAYS call task_done() - each get() from queue needs a corresponding task_done()
+                # This MUST be in a finally block to ensure it's called even if the worker crashes.
+                # Requeued items are NEW tasks that will get their own task_done() when processed.
+                Neo4jTransactor.queue.task_done()


### PR DESCRIPTION
## Summary

This PR adds a configuration-driven approach to switch specific ETL types from parallel to sequential sub-type loading, preventing Neo4j deadlocks when multiple MODs update shared nodes concurrently.

**Problem:** The AGR Loader uses multiprocessing to load data from multiple MODs in parallel within certain ETL classes (PhenotypeETL, DiseaseETL, etc.). This causes Neo4j deadlocks (`TransientError.Transaction.DeadlockDetected`) when multiple processes try to update the same Gene nodes simultaneously.

**Solution:** Add `SEQUENTIAL_ETL_TYPES` configuration option that allows specific ETL types to load their sub-types one at a time instead of in parallel.

## Changes

- **`src/default_env_vars.yml`** - Add `SEQUENTIAL_ETL_TYPES` config option (default: empty = parallel)
- **`src/etl/etl.py`** - Add `process_sub_types_with_threading()` helper method to ETL base class
- **`src/etl/phenotype_etl.py`** - Refactor to use helper method
- **`src/etl/disease_etl.py`** - Refactor to use helper with `cleanup_func` parameter
- **`src/etl/orthology_etl.py`** - Refactor to use helper with wrapper function
- **`src/etl/go_annot_etl.py`** - Refactor to use helper with wrapper function

## Usage

```bash
# Enable sequential loading for specific ETL types (prevents deadlocks)
export SEQUENTIAL_ETL_TYPES="PHENOTYPE,DAF,GAF,ORTHO"

# Or just the problematic ones
export SEQUENTIAL_ETL_TYPES="PHENOTYPE,DAF"

# Default (empty) = all ETLs run in parallel (backward compatible)
```

## Key Features

- **Backward compatible** - Default behavior (parallel) unchanged when config is empty
- **Environment override** - Can be set via env var without code deployment
- **Case insensitive** - `"phenotype,Daf"` works
- **Whitespace tolerant** - `" PHENOTYPE , DAF "` works
- **Clear logging** - Logs indicate which mode is active for each ETL
- **DiseaseETL cleanup** - `delete_empty_nodes()` runs after EACH sub-type in sequential mode (once after all in parallel mode)

## Test Plan

- [ ] Verify parallel mode (default) works unchanged
- [ ] Test sequential mode for single ETL type
- [ ] Test sequential mode for multiple ETL types
- [ ] Verify DiseaseETL cleanup behavior in both modes
- [ ] Automated CI tests pass