### PR TITLE
KANBAN-965: fix Vma21 worm orthology flags

### DIFF
--- a/src/etl/orthology_etl.py
+++ b/src/etl/orthology_etl.py
@@ -18,6 +18,14 @@ class OrthologyETL(ETL):
     """Orthology ETL."""
 
     logger = logging.getLogger(__name__)
+    ORTHOLOGY_FLAG_OVERRIDES = {
+        frozenset(("MGI:1914298", "WB:WBGene00011116")): {
+            "isBestScore": False,
+            "isBestRevScore": False,
+            "strictFilter": False,
+            "moderateFilter": False
+        }
+    }
 
     # Query templates which take params and will be processed later
 
@@ -224,6 +232,19 @@ class OrthologyETL(ETL):
 
         return list_o
 
+    @classmethod
+    def apply_orthology_flag_overrides(cls, gene_1_agr_primary_id, gene_2_agr_primary_id, ortho_dataset):
+        """Apply curated overrides for known-bad orthology flag assignments."""
+        override = cls.ORTHOLOGY_FLAG_OVERRIDES.get(
+            frozenset((gene_1_agr_primary_id, gene_2_agr_primary_id))
+        )
+        if override is None:
+            return ortho_dataset
+
+        corrected_dataset = ortho_dataset.copy()
+        corrected_dataset.update(override)
+        return corrected_dataset
+
     def get_generators(self, datafile, sub_type, sub_types, batch_size):  # noqa
         """Get Generators."""
         counter = 0
@@ -286,6 +307,11 @@ class OrthologyETL(ETL):
                         'moderateFilter': ortho_record['moderateFilter'],
                         'uuid': ortho_uuid
                     }
+                    ortho_dataset = self.apply_orthology_flag_overrides(
+                        gene_1_agr_primary_id,
+                        gene_2_agr_primary_id,
+                        ortho_dataset
+                    )
                     list_of_mod_lists[gene_2_data_provider].append(ortho_dataset)
 
                     for matched in ortho_record.get('predictionMethodsMatched'):

--- a/src/test/unit_tests.py
+++ b/src/test/unit_tests.py
@@ -5,6 +5,7 @@ Tests that methods return what they should etc.
 Remember to remove bad_pages test once the olf code has been removed.
 """
 from etl.helpers import ETLHelper
+from etl.orthology_etl import OrthologyETL
 
 
 class TestClass():
@@ -91,3 +92,44 @@ class TestClass():
         for item_name in self.etlh.rdh2.bad_regex.keys():
             assert 1 == self.etlh.rdh2.bad_regex[item_name]
             assert item_name == 'MESH'
+
+    def test_apply_orthology_flag_overrides_for_vma21_pdcd2(self):
+        """Known-bad Vma21/pdcd-2 best orthology flags are demoted."""
+        ortho_dataset = {
+            'isBestScore': True,
+            'isBestRevScore': True,
+            'strictFilter': True,
+            'moderateFilter': True,
+            'confidence': '0.5',
+            'uuid': 'test-uuid'
+        }
+
+        corrected_dataset = OrthologyETL.apply_orthology_flag_overrides(
+            'MGI:1914298',
+            'WB:WBGene00011116',
+            ortho_dataset
+        )
+
+        assert corrected_dataset['isBestScore'] is False
+        assert corrected_dataset['isBestRevScore'] is False
+        assert corrected_dataset['strictFilter'] is False
+        assert corrected_dataset['moderateFilter'] is False
+        assert corrected_dataset['confidence'] == ortho_dataset['confidence']
+        assert corrected_dataset['uuid'] == ortho_dataset['uuid']
+
+    def test_apply_orthology_flag_overrides_leaves_other_pairs_unchanged(self):
+        """Unlisted orthology pairs should pass through unchanged."""
+        ortho_dataset = {
+            'isBestScore': True,
+            'isBestRevScore': True,
+            'strictFilter': True,
+            'moderateFilter': True
+        }
+
+        corrected_dataset = OrthologyETL.apply_orthology_flag_overrides(
+            'MGI:1914298',
+            'WB:WBGene00303105',
+            ortho_dataset
+        )
+
+        assert corrected_dataset == ortho_dataset


### PR DESCRIPTION
## Summary
This change prevents a known bad DIOPT-derived orthology assignment from presenting mouse Vma21 and worm pdcd-2 as a best or strict ortholog pair. The override keeps the underlying relationship data available while removing the misleading ranking flags until the upstream source data is corrected.

## Changes
- Added a curated orthology flag override for the `MGI:1914298` and `WB:WBGene00011116` pair during orthology ingestion.
- Added unit coverage for the Vma21 and pdcd-2 override behavior.
- Added unit coverage confirming that nearby worm orthology pairs continue to pass through unchanged.

## Testing
- Added targeted unit tests in `src/test/unit_tests.py` for the override and non-override cases.
- Ran `python3 -m py_compile src/etl/orthology_etl.py src/test/unit_tests.py`.
- Could not run `pytest` in this workspace because the `pytest` module is not installed.
