### PR TITLE
KANBAN-965 temporarily filter bad VMA21 orthology pairs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,117 @@
+# Gitleaks configuration template for Git Safety Project
+# This file is copied to repositories by install_git_hooks.py
+# Updated: 2025-12-10 - Added Alliance Genome Ansible vault password protection
+
+title = "Git Safety Project - Secret Detection"
+
+[extend]
+# Use default gitleaks rules as base
+useDefault = true
+
+[allowlist]
+description = "Safe patterns - minimal exclusions for security"
+# Only exclude truly safe patterns like .git internals
+paths = [
+    '''\.git/''',
+    '''node_modules/''',
+    '''venv/''',
+    '''\.venv/''',
+    '''__pycache__/''',
+]
+
+# Only allow example/placeholder patterns, not real secrets
+regexes = [
+    # Documentation examples only
+    '''AKIAEXAMPLE[A-Z0-9]{8}''',
+    '''XXXXXXXXXXXX''',
+    '''123456789012''',
+    '''i-REDACTED''',
+    '''sk-EXAMPLE''',
+]
+
+# ============================================================
+# CRITICAL: Alliance Genome Ansible Vault Password Protection
+# ============================================================
+# Protects ansible vault passwords used for AWS infrastructure credentials,
+# database passwords, and API tokens across production systems.
+# Pattern-based detection to avoid hardcoding actual secrets.
+
+[[rules]]
+id = "ansible-vault-password-pattern"
+description = "Ansible Vault Password Pattern (32-char hex)"
+# Catches common contexts where vault passwords appear:
+# - .password files with 32-char hex
+# - echo commands with 32-char hex
+# - Variable assignments with 32-char hex in ansible contexts
+regex = '''(?i)(password|vault|ansible)["\s:=]+[a-f0-9]{32}'''
+keywords = ["password", "vault", "ansible"]
+tags = ["alliance", "ansible", "critical"]
+
+[[rules]]
+id = "ansible-vault-password-partial-match"
+description = "Ansible Vault Password Partial Match (FAILSAFE)"
+# Failsafe: Catches strings with specific start/end patterns
+# Uses first 3 and last 3 characters as fingerprint (minimal exposure)
+regex = '''512[a-f0-9]{26}e42'''
+tags = ["alliance", "ansible", "critical", "failsafe"]
+
+[[rules]]
+id = "ansible-vault-password-file"
+description = "Ansible Vault Password in .password files"
+# Specifically catches passwords in .password files or similar
+regex = '''[a-f0-9]{32}'''
+paths = [
+    '''.password$''',
+    '''password\.txt$''',
+    '''vault\.txt$''',
+    '''ansible_vault''',
+]
+tags = ["ansible", "password-file"]
+
+[[rules]]
+id = "echo-password-command"
+description = "Echo command with potential vault password"
+# Catches echo commands that might be writing passwords to files
+regex = '''echo\s+(-n\s+)?['"]*[a-f0-9]{32}['"]*\s*[>|]'''
+keywords = ["echo"]
+tags = ["command", "password"]
+
+# ============================================================
+# Additional Custom Rules
+# ============================================================
+
+[[rules]]
+id = "ansible-vault-password-generic"
+description = "Generic Ansible Vault Password Pattern"
+regex = '''vault_password\s*[:=]\s*[a-f0-9]{32}'''
+keywords = ["vault_password"]
+
+[[rules]]
+id = "elevenlabs-api-key"
+description = "ElevenLabs API Key"
+regex = '''sk_[a-f0-9]{32}'''
+keywords = ["elevenlabs", "sk_"]
+
+[[rules]]
+id = "mem0-api-key"
+description = "Mem0 API Key"
+regex = '''m0-[A-Za-z0-9]{20,}'''
+keywords = ["mem0", "m0-"]
+
+[[rules]]
+id = "langsmith-api-key"
+description = "LangSmith API Key"
+regex = '''lsv2_pt_[a-f0-9]{20,}'''
+keywords = ["langsmith", "lsv2_pt_"]
+
+[[rules]]
+id = "aws-session-token"
+description = "AWS Session Token"
+regex = '''(?i)(aws_session_token|AWS_SESSION_TOKEN)\s*[:=]\s*['"]?[A-Za-z0-9+/]{200,}={0,2}['"]?'''
+keywords = ["aws_session_token", "AWS_SESSION_TOKEN"]
+
+[[rules]]
+id = "github-fine-grained-pat"
+description = "GitHub Fine-Grained Personal Access Token"
+regex = '''github_pat_[0-9a-zA-Z_]{82}'''
+keywords = ["github_pat_"]

--- a/src/etl/orthology_etl.py
+++ b/src/etl/orthology_etl.py
@@ -18,6 +18,14 @@ class OrthologyETL(ETL):
     """Orthology ETL."""
 
     logger = logging.getLogger(__name__)
+    # KANBAN-965 temporary fix: exclude the known bad DIOPT VMA21/pdcd-2 pairs
+    # until the upstream orthology source data is corrected.
+    excluded_gene_pairs = {
+        frozenset({"WB:WBGene00011116", "HGNC:22082"}),
+        frozenset({"WB:WBGene00011116", "MGI:1914298"}),
+        frozenset({"WB:WBGene00011116", "Xenbase:XB-GENE-5730849"}),
+        frozenset({"WB:WBGene00011116", "ZFIN:ZDB-GENE-081104-272"}),
+    }
 
     # Query templates which take params and will be processed later
 
@@ -84,6 +92,11 @@ class OrthologyETL(ETL):
         """Initialise object."""
         super().__init__()
         self.data_type_config = config
+
+    @classmethod
+    def is_excluded_gene_pair(cls, gene_1_agr_primary_id, gene_2_agr_primary_id):
+        """Return True when a pair should be skipped during orthology loading."""
+        return frozenset({gene_1_agr_primary_id, gene_2_agr_primary_id}) in cls.excluded_gene_pairs
 
     def _load_and_process_data(self):
 
@@ -272,6 +285,8 @@ class OrthologyETL(ETL):
                         continue
 
                 if gene_1_agr_primary_id is not None and gene_2_agr_primary_id is not None:
+                    if self.is_excluded_gene_pair(gene_1_agr_primary_id, gene_2_agr_primary_id):
+                        continue
 
                     ortho_dataset = {
                         'isBestScore': ortho_record['isBestScore'],

--- a/src/test/unit_tests.py
+++ b/src/test/unit_tests.py
@@ -5,6 +5,7 @@ Tests that methods return what they should etc.
 Remember to remove bad_pages test once the olf code has been removed.
 """
 from etl.helpers import ETLHelper
+from etl import OrthologyETL
 
 
 class TestClass():
@@ -91,3 +92,19 @@ class TestClass():
         for item_name in self.etlh.rdh2.bad_regex.keys():
             assert 1 == self.etlh.rdh2.bad_regex[item_name]
             assert item_name == 'MESH'
+
+    def test_orthology_excluded_gene_pairs(self):
+        """Only the ticketed DIOPT VMA21/pdcd-2 pairs should be excluded."""
+        blocked_pairs = [
+            ("WB:WBGene00011116", "HGNC:22082"),
+            ("WB:WBGene00011116", "MGI:1914298"),
+            ("WB:WBGene00011116", "Xenbase:XB-GENE-5730849"),
+            ("WB:WBGene00011116", "ZFIN:ZDB-GENE-081104-272"),
+        ]
+
+        for gene_1, gene_2 in blocked_pairs:
+            assert OrthologyETL.is_excluded_gene_pair(gene_1, gene_2) is True
+            assert OrthologyETL.is_excluded_gene_pair(gene_2, gene_1) is True
+
+        assert OrthologyETL.is_excluded_gene_pair("WB:WBGene00011116", "RGD:1566155") is False
+        assert OrthologyETL.is_excluded_gene_pair("WB:WBGene00011115", "HGNC:22082") is False


### PR DESCRIPTION
## Summary
- add a temporary KANBAN-965 orthology blacklist for the known bad DIOPT VMA21/pdcd-2 pairs
- apply the filter during orthology load after AGR ID normalization so both directions are skipped consistently
- add a focused unit test for the excluded pair helper and guard against filtering the rat or R07E5.7 cases

## Validation
- pre-commit gitleaks and trufflehog hooks passed during commit
- targeted verification script against the current downloaded ORTHO subtype files confirmed exactly the 8 ticketed source rows are filtered
- direct local pytest collection with system Python is still blocked outside the project runtime because that environment is missing the repo's `neo4j` dependency