### PR TITLE
KANBAN-965: clean up stale excluded orthology pairs

### DIFF
--- a/src/etl/orthology_etl.py
+++ b/src/etl/orthology_etl.py
@@ -20,12 +20,13 @@ class OrthologyETL(ETL):
     logger = logging.getLogger(__name__)
     # KANBAN-965 temporary fix: exclude the known bad DIOPT VMA21/pdcd-2 pairs
     # until the upstream orthology source data is corrected.
-    excluded_gene_pairs = {
-        frozenset({"WB:WBGene00011116", "HGNC:22082"}),
-        frozenset({"WB:WBGene00011116", "MGI:1914298"}),
-        frozenset({"WB:WBGene00011116", "Xenbase:XB-GENE-5730849"}),
-        frozenset({"WB:WBGene00011116", "ZFIN:ZDB-GENE-081104-272"}),
-    }
+    excluded_gene_pair_tuples = (
+        ("WB:WBGene00011116", "HGNC:22082"),
+        ("WB:WBGene00011116", "MGI:1914298"),
+        ("WB:WBGene00011116", "Xenbase:XB-GENE-5730849"),
+        ("WB:WBGene00011116", "ZFIN:ZDB-GENE-081104-272"),
+    )
+    excluded_gene_pairs = {frozenset(pair) for pair in excluded_gene_pair_tuples}
 
     # Query templates which take params and will be processed later
 
@@ -98,7 +99,43 @@ class OrthologyETL(ETL):
         """Return True when a pair should be skipped during orthology loading."""
         return frozenset({gene_1_agr_primary_id, gene_2_agr_primary_id}) in cls.excluded_gene_pairs
 
+    @classmethod
+    def get_excluded_gene_pair_cleanup_query(cls):
+        """Build a Cypher query that removes stale excluded orthology pairs."""
+        excluded_pair_conditions = []
+
+        for gene_1_agr_primary_id, gene_2_agr_primary_id in cls.excluded_gene_pair_tuples:
+            excluded_pair_conditions.append(
+                "(g1.primaryKey = '{gene_1}' AND g2.primaryKey = '{gene_2}')".format(
+                    gene_1=gene_1_agr_primary_id,
+                    gene_2=gene_2_agr_primary_id
+                )
+            )
+            excluded_pair_conditions.append(
+                "(g1.primaryKey = '{gene_2}' AND g2.primaryKey = '{gene_1}')".format(
+                    gene_1=gene_1_agr_primary_id,
+                    gene_2=gene_2_agr_primary_id
+                )
+            )
+
+        where_clause = " OR ".join(excluded_pair_conditions)
+
+        return """
+            MATCH (g1:Gene)-[orth:ORTHOLOGOUS]-(g2:Gene)
+            WHERE {where_clause}
+            OPTIONAL MATCH (g1)-[:ASSOCIATION]->(ogj:OrthologyGeneJoin)-[:ASSOCIATION]->(g2)
+            OPTIONAL MATCH (ogj)-[algo_rel:MATCHED|NOT_MATCHED|NOT_CALLED]-(:OrthoAlgorithm)
+            WITH collect(DISTINCT orth) AS orths,
+                 collect(DISTINCT ogj) AS joins,
+                 collect(DISTINCT algo_rel) AS algo_rels
+            FOREACH (orth IN orths | DELETE orth)
+            FOREACH (algo_rel IN algo_rels | DELETE algo_rel)
+            FOREACH (join IN joins | DETACH DELETE join)
+        """.format(where_clause=where_clause)
+
     def _load_and_process_data(self):
+        self.logger.info("Removing excluded orthology pairs before load")
+        Neo4jHelper.run_single_query_no_return(self.get_excluded_gene_pair_cleanup_query())
 
         self.load_algorithm = """
             CREATE (oa:OrthoAlgorithm)
@@ -165,6 +202,9 @@ class OrthologyETL(ETL):
 
         Neo4jTransactor.execute_query_batch(algo_queries)
         self.error_messages()
+
+        self.logger.info("Removing excluded orthology pairs after load")
+        Neo4jHelper.run_single_query_no_return(self.get_excluded_gene_pair_cleanup_query())
 
     def _process_sub_type(self, sub_type, sub_types, query_tracking_list):
         self.logger.info("Loading Orthology Data: %s", sub_type.get_data_provider())

--- a/src/test/unit_tests.py
+++ b/src/test/unit_tests.py
@@ -108,3 +108,23 @@ class TestClass():
 
         assert OrthologyETL.is_excluded_gene_pair("WB:WBGene00011116", "RGD:1566155") is False
         assert OrthologyETL.is_excluded_gene_pair("WB:WBGene00011115", "HGNC:22082") is False
+
+    def test_orthology_excluded_gene_pair_cleanup_query(self):
+        """The cleanup query should remove stale copies of the excluded orthology pairs."""
+        cleanup_query = OrthologyETL.get_excluded_gene_pair_cleanup_query()
+
+        blocked_pairs = [
+            ("WB:WBGene00011116", "HGNC:22082"),
+            ("WB:WBGene00011116", "MGI:1914298"),
+            ("WB:WBGene00011116", "Xenbase:XB-GENE-5730849"),
+            ("WB:WBGene00011116", "ZFIN:ZDB-GENE-081104-272"),
+        ]
+
+        for gene_1, gene_2 in blocked_pairs:
+            assert gene_1 in cleanup_query
+            assert gene_2 in cleanup_query
+
+        assert "DETACH DELETE join" in cleanup_query
+        assert "DELETE orth" in cleanup_query
+        assert "DELETE algo_rel" in cleanup_query
+        assert "RGD:1566155" not in cleanup_query


### PR DESCRIPTION
## Summary
This change makes the KANBAN-965 orthology suppression robust in incremental Neo4j loads, not just fresh rebuilds. The previous filter prevented new bad VMA21/pdcd-2 rows from loading, but it did not remove stale relationships that were already present in an existing database, which could leave stage still showing the incorrect best ortholog.

## Changes
- Refactored the excluded VMA21/pdcd-2 pairs into a shared tuple list and derived set so the loader can use the same source of truth for both filtering and cleanup.
- Added a Cypher cleanup query that deletes the known bad orthology relationships, their orthology join nodes, and their matched or unmatched algorithm relationships.
- Ran the cleanup query before and after the orthology ETL so incremental reloads can remove stale bad data as well as block it from being reinserted.
- Added unit coverage for the cleanup query alongside the existing excluded-pair checks.

## Testing
- Verified manually that the live stage API still exposed the bad `MGI:1914298` to `WB:WBGene00011116` orthology before this loader hardening.
- Ran `python3 -m py_compile src/etl/orthology_etl.py src/test/unit_tests.py` successfully.
- Could not run `pytest` in this environment because `pytest` is not installed.
